### PR TITLE
Added helper to convert newlines to break tags in results template

### DIFF
--- a/searchtool/server/server.js
+++ b/searchtool/server/server.js
@@ -19,6 +19,11 @@ hbs.registerHelper('truncate', function(passedString) {
     var theString = passedString.substring(0,900);
     return new hbs.SafeString(theString)
 });
+hbs.registerHelper('breaklines', function(text) {
+    text = hbs.Utils.escapeExpression(text);
+    text = text.replace(/(\r\n|\n|\r)/gm, '<br>');
+    return new hbs.SafeString(text);
+});
 // must be set to serve views properly when starting the app via `slc run` from
 // the project rootapp.set('views', path.join(__dirname, 'views'));
 

--- a/searchtool/server/views/newview.hbs
+++ b/searchtool/server/views/newview.hbs
@@ -16,7 +16,7 @@
           {{#each result}}
 
             <div class="media">
-              <h4>  <a style="cursor:pointer"; onClick="javascript:document.getElementById('action_text').innerHTML =''; document.getElementById('action_text').innerHTML ='<b>File Doc Id:</b>{{filename}} , <b>Action Type:</b> {{action_type.[0]}} , <b>Search Term:</b> {{../term}}<hr>{{textdata.[0]}}';"  data-item="{{filename}}" data-toggle="modal" data-target="#cancelModal">  Office Action ID: {{filename}}</a> | {{action_type.[0]}}</h4>
+              <h4>  <a style="cursor:pointer"; onClick="javascript:document.getElementById('action_text').innerHTML =''; document.getElementById('action_text').innerHTML ='<b>File Doc Id:</b>{{filename}} , <b>Action Type:</b> {{action_type.[0]}} , <b>Search Term:</b> {{../term}}<hr>{{breaklines textdata.[0]}}';"  data-item="{{filename}}" data-toggle="modal" data-target="#cancelModal">  Office Action ID: {{filename}}</a> | {{action_type.[0]}}</h4>
               {{#with (lookup ../highlighting id) }}
                 {{#if textdata}}
                   {{#each textdata}}


### PR DESCRIPTION
Fixes the blank modal issue by handling `\n` characters in the ptab data strings

cc: @bahadasx 
