### PR TITLE
Use CDS fork of pagination plugin

### DIFF
--- a/searchtool/package.json
+++ b/searchtool/package.json
@@ -35,7 +35,7 @@
     "loopback-connector-mysql": "^2.2.1",
     "loopback-datasource-juggler": "^2.39.0",
     "moment": "^2.12.0",
-    "nodejs-yapaginate": "0.0.9",
+    "nodejs-yapaginate": "https://github.com/CommerceDataService/nodejs-yapaginate",
     "serve-favicon": "^2.0.1",
     "supertest": "^1.1.0",
     "unirest": "0.4.2"


### PR DESCRIPTION
- to fix styling issue (mismatch between Bootstrap's styles and
  pagination lib's tag/class output)

I couldn't test this locally, as my home IP seems to no longer be on the whitelist. But I think I did test it in the past.

cc @bahadasx 
