### PR TITLE
Add functionality to 'Clear' link on page, Fixes #82

### DIFF
--- a/searchtool/server/views/layout.hbs
+++ b/searchtool/server/views/layout.hbs
@@ -155,7 +155,7 @@
               </div>
               {{#if accessOK}}
                   <div class="filter-heading">
-                    <span tabindex="0" class="h4">Refine by</span> <a class="filters-clear" href="">Clear</a>
+                    <span tabindex="0" class="h4">Refine by</span> <a class="filters-clear" href="/newsearch">Clear</a>
                   </div>
               {{/if}}
 


### PR DESCRIPTION
Done by adding '/newsearch' to the href on the 'a' tag
