### PR TITLE
UI improvement. Fixes #84 & #85

### DIFF
--- a/searchtool/client/scripts/script.js
+++ b/searchtool/client/scripts/script.js
@@ -105,3 +105,10 @@ $('.switch')
         $('.js-filterSwitch').addClass('hide');
         $(attr).toggleClass('hide');
     });
+
+function resizeText(multiplier) {
+  if (document.getElementById('results').style.fontSize == "") {
+    document.getElementById('results').style.fontSize = "1.0em";
+  }
+  document.getElementById('results').style.fontSize = parseFloat(document.getElementById('results').style.fontSize) + (multiplier * 0.2) + "em";
+}

--- a/searchtool/client/scripts/script.js
+++ b/searchtool/client/scripts/script.js
@@ -146,4 +146,4 @@ documentcodeObj.forEach(function(value,index) {
     if (URL.indexOf(value) > -1) {
         $('#documentcodeID option[value="' + value + '"]').prop('selected', true);
     }
-})
+});

--- a/searchtool/client/styles/layout_custom.css
+++ b/searchtool/client/styles/layout_custom.css
@@ -1,3 +1,6 @@
+@-ms-viewport {
+	width: auto !important;
+}
 .help-button a {
 	margin-bottom: 15px;
 	margin-top: 15px;

--- a/searchtool/client/styles/layout_custom.css
+++ b/searchtool/client/styles/layout_custom.css
@@ -1,10 +1,6 @@
 @-ms-viewport {
 	width: auto !important;
 }
-.help-button a {
-	margin-bottom: 15px;
-	margin-top: 15px;
-}
 .external-link{
 	display: block;
 }

--- a/searchtool/server/boot/routes.js
+++ b/searchtool/server/boot/routes.js
@@ -69,7 +69,10 @@ module.exports = function(app) {
 
 
     router.get('/help', function(req, res) {
-        res.render('help');
+        res.render('help', {
+            email: req.body.email,
+            accessOK: !!(! config.requireLogin || token.id)
+        });
     });
 
     // Main Search

--- a/searchtool/server/boot/search.js
+++ b/searchtool/server/boot/search.js
@@ -36,8 +36,7 @@ exports.buildSearch = function (req, res) {
     // Ensure q var is cast to string
     if (req.query.q) {
         q=req.query.q.toString();
-    }else{q="*:*"}
-
+    }else{q="*:*";}
 
     // Art Unit Filter
     if ((typeof req.query.art_unit !== 'undefined') && (req.query.art_unit.length < 7) && (req.query.art_unit.length > 0)) {

--- a/searchtool/server/boot/search.js
+++ b/searchtool/server/boot/search.js
@@ -36,7 +36,7 @@ exports.buildSearch = function (req, res) {
     // Ensure q var is cast to string
     if (req.query.q) {
         q=req.query.q.toString();
-    }
+    }else{q="*:*"}
 
 
     // Art Unit Filter
@@ -81,7 +81,7 @@ exports.buildSearch = function (req, res) {
                 res.render('newview', {
                     result:body.response.docs,
                     total:humanize.numberFormat(body.response.numFound,0),
-                    pagein:paginate({totalItem:body.response.numFound, itemPerPage:20, currentPage:currentPage, url:'/newsearch',params: {q: q, dataset: req.query.dataset, fromdate: req.query.fromdate, todate: req.query.todate, art_unit: req.query.art_unit, documentcode: req.query.documentcode} }),
+                    pagein:paginate({totalItem:body.response.numFound, itemPerPage:20, currentPage:currentPage, url:'/newsearch',params: {q: q, dataset: req.query.dataset, fromdate: req.query.fromdate, todate: req.query.todate, artunit: req.query.art_unit, documentcode: req.query.documentcode} }),
                     took:humanize.numberFormat(body.responseHeader.QTime,0 ),
                     highlighting:body.highlighting,
                     term:q,
@@ -90,7 +90,7 @@ exports.buildSearch = function (req, res) {
                     accessOK: !!(! config.requireLogin || token.id),
                     todate: req.query.todate,
                     fromdate:req.query.fromdate,
-                    artUnit: req.query.art_unit,
+                    artunit: req.query.art_unit,
                     documentcode: req.query.documentcode
                 });
             } else {

--- a/searchtool/server/views/layout.hbs
+++ b/searchtool/server/views/layout.hbs
@@ -151,8 +151,8 @@
                     </div>
                   </div>
                 </div>
-                <span class="input-group-btn">
-                  <button class="btn btn-primary" style="z-index: 1;">Refine Search</button>
+                <span class="input-group-btn text-center">
+                  <button class="btn btn-primary">Refine Search</button>
                 </span>
               </form>
             </div>

--- a/searchtool/server/views/layout.hbs
+++ b/searchtool/server/views/layout.hbs
@@ -111,7 +111,7 @@
                   </div>
                 </div>
                 <div class="filter">
-                  <label for="s2id_autogen2" class="h5 control-label">Select Document Code</label>
+                  <label for="s2id_autogen2" class="h5 control-label">Select Action Type</label>
                   <select class="select2 form-control" tabindex="-1" title="" name="documentcode" id="documentcodeID">
                     <option selected disabled>Choose here</option>
                     <option value="RXCTIN">INTERFERENCE COMMUNICATION: INITIAL MEMO</option>
@@ -169,7 +169,7 @@
                         {{/if}}
                         {{#if artunit}}<span> Art Unit: <span class="label label-success subtle">{{artunit}}</span></span>
                         {{/if}}
-                        {{#if documentcode}}<span> Document Code: </span><span class="label label-success subtle">{{documentcode}}</span>
+                        {{#if documentcode}}<span> Action Type: </span><span class="label label-success subtle">{{documentcode}}</span>
                         {{/if}}
                         {{#if fromdate}}<span> Date Range: </span><span class="label label-success subtle">{{fromdate}} - {{todate}}</span>
                         {{/if}}

--- a/searchtool/server/views/layout.hbs
+++ b/searchtool/server/views/layout.hbs
@@ -9,7 +9,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
   <meta name="theme-color" content="#004c97">
   <meta property="og:title" content="Customize search results">
-  <meta property="og:description" content="">  <link rel="shortcut icon" href="/bower_components/designpatterns/generated/favicon.ico">
+  <meta property="og:description" content="">
+  <link rel="shortcut icon" href="/bower_components/designpatterns/generated/favicon.ico">
   <link href="/bower_components/designpatterns/generated/styles/vendor.css" rel="stylesheet" />
   <link href="/bower_components/designpatterns/generated/styles/main.css" rel="stylesheet" />
   <link href="/bower_components/designpatterns/generated/styles/appDemo.min.css" rel="stylesheet" />
@@ -26,7 +27,7 @@
     <nav class="navbar navbar-inverse">
       <div class="container-fluid container--full">
         <div class="navbar-header">
-        <a href="/designpatterns/index.html" class="navbar-brand"><strong>USPTO</strong> <span class="light">Patent Quality Search Tool</span></a>
+          <a href="/designpatterns/index.html" class="navbar-brand"><strong>USPTO</strong> <span class="light">Patent Quality Search Tool</span></a>
         </div>
         <ul class="nav navbar-nav">
           <li>
@@ -49,7 +50,6 @@
       </div>
     </nav>
   </header>
-
   <main class="wrapper container-fluid container--full">
     <div class="row-grid">
       <div class="pane-center col">
@@ -59,12 +59,11 @@
             {{#if accessOK}}
               <form role="form" action="/newsearch" class="padding-top-2 padding-right-2 padding-bottom-2">
                 <h2 class="margin-top-0">Patent Data Search</h2>
-                <div class="form-group col-sm-5">
                 <div class="input-search input-group">
-                  <input type="text" name="q" value="{{#if term}}{{term}}{{/if}}" aria-label="Search all fields" title="Search all fields" class="form-control" placeholder="Search all fields" id="txt-find">
+                  <input type="text" name="q" value="{{term}}" aria-label="Search all fields" title="Search all fields" class="form-control" placeholder="Search all fields" id="txt-find">
                   <span class="input-group-btn">
-                    <button class="btn btn-primary"><i class="icon icon-inverse icon-search"></i></button>
-                  </span>
+                  <button class="btn btn-primary"><i class="icon icon-inverse icon-search"></i></button>
+                </span>
                 </div>
                 <label class="radio-inline">
                   <input type="radio" name="dataset" id="inlineRadio1" value="oa" {{#unless ptab}} checked {{/unless}}> Office Actions
@@ -75,98 +74,117 @@
                 <div style="margin-bottom: 0;" class="help-block">
                   <b><i>Examples: Search for law 112(f)...<code>"112\(f\)"</code> or for Art Unit... <code>"Art Unit 3669"~2</code>  </i></b>
                 </div>
+              </form>
+            {{/if}}
+            {{#unless accessOK}}
+              This Search engine is for authorized users only.
+              <hr> For access, please contact Thomas Beach
+            {{/unless}}
+          </div>
+          <div class="main-wrapper row-grid">
+            <div class="app-sidebar filters keyline-right">
+              <a tabindex="-1" id="filters"></a>
+              <div class="filter-heading">
+                <span tabindex="0" class="h4">Refine by</span> <a class="filters-clear" href="">Clear</a>
               </div>
-                <div class="form-group col-sm-1">
-                  <span class="input-icon icon icon-calendar-o"></span>
-                  <input name="fromdate" type="text" placeholder="Start" class="datepicker form-control" value="{{fromdate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="Start date" aria-label="Start date">
+              <form class="filters-flat js-filterSwitch" role="form" action="/newsearch">
+                <div class="filter hide">
+                  <input type="text" name="q" value="{{term}}" aria-label="Search all fields" title="Search all fields" class="form-control hide" placeholder="Search all fields" id="txt-find">
                 </div>
-                <div class="form-group col-sm-1">
-                  <span class="input-icon icon icon-calendar-o"></span>
-                  <input name="todate" type="text" placeholder="End" class="datepicker form-control" value="{{todate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="End date" aria-label="End date">
-                </div>
-                <div class="form-group col-sm-2">
-                  <input type="text" name="art_unit" aria-label="Search Art Unit Number" title="Search Art Unit Number" class="form-control" placeholder="Search Art Unit Number" value="{{#if artUnit}}{{artUnit}}{{/if}}">
-                  <div style="margin-bottom: 0;" class="help-block">
-                    <b><i>Example: Search for Art Unit number <code>3669~2</code></i></b>
+                <div class="filter">
+                  <div class="h5" tabindex="0">Document Date</div>
+                  <div class="form-group">
+                    <span class="input-icon icon icon-calendar-o"></span>
+                    <input name="fromdate" type="text" placeholder="Start" class="datepicker form-control" value="{{fromdate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="Start date" aria-label="Start date">
+                  </div>
+                  <div class="form-group margin-bottom-0">
+                    <span class="input-icon icon icon-calendar-o"></span>
+                    <input name="todate" type="text" placeholder="End" class="datepicker form-control" value="{{todate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="End date" aria-label="End date">
                   </div>
                 </div>
-                <select name="documentcode" id="documentcodeID">
-                  <option value="">Please choose a document code</option>
-                  <option value="RXCTIN">INTERFERENCE COMMUNICATION: INITIAL MEMO:RXCTIN</option>
-                  <option value="RDIN">RX - DECISION STAYING REEXAM IN FAVOR OF INTERFERENCE:RDIN</option>
-                  <option value="M327-D">PUB OTHER MISCELLANEOUS COMMUNICATION TO APPLICANT:M327-D</option>
-                  <option value="CTNF">NON-FINAL REJECTION:CTNF</option>
-                  <option value="CNTA">ALLOWABILITY NOTICE:CNTA</option>
-                  <option value="CTFR">FINAL REJECTION:CTFR</option>
-                  <option value="CNOA">CORRECTED NOTICE OF ALLOWABILITY:CNOA</option>
-                  <option value="N271">RESPONSE TO AMENDMENT UNDER RULE 312:N271</option>
-                  <option value="REXD">RX - EX PARTE REEXAM ORDER - DENIED:REXD</option>
-                  <option value="EX.R">REASONS FOR ALLOWANCE:EX.R</option>
-                  <option value="RTDE">RX - PETITION DECISION - DENIED:RTDE</option>
-                  <option value="INTNO">INTERFERENCE NOTIFICATION TO PATENTEE RULE 607:INTNO</option>
-                  <option value="L.SI">SUSPENSION - INTERFERENCE IN ANOTHER CASE:L.SI</option>
-                  <option value="RXBPAI">REEXAM FORWARDED TO BOARD OF PATENT APPEALS AND INTERFERENCES:RXBPAI</option>
-                  <option value="RXSRXI">DECISION STAYING REEXAM PROCEEDING IN FAVOR OF INTERFERENCE PROCEEDING:RXSRXI</option>
-                  <option value="CTMS">MISCELLANEOUS ACTION WITH SSP:CTMS</option>
-                  <option value="M327">MISCELLANEOUS COMMUNICATION TO APPLICANT - NO ACTION COUNT:M327</option>
-                  <option value="M327-E">BOA MISCELLANEOUS COMMUNICATION TO APPLICANT:M327-E</option>
-                  <option value="P132">MISCELLANEOUS COMMUNICATION:P132</option>
-                  <option value="R327">RX - MISCELLANEOUS COMMUNICATION TO APPLICANT:R327</option>
-                  <option value="RXM327">MISCELLANEOUS COMMUNICATION TO APPLICANT:RXM327</option>
-                  <option value="RXMISC">MISCELLANEOUS ACTION MAILED:RXMISC</option>
-                  <option value="RXMMIS">MISCELLANEOUS LETTER MAILED:RXMMIS</option>
-                  <option value="SEMI">SE - MISCELLANEOUS DECISION/OFFICE NOTICE IN SE:SEMI</option>
-                  <option value="RTGR">RX - PETITION DECISION - GRANTED:RTGR</option>
-                  <option value="RTDI">RX - PETITION DECISION - DISMISSED:RTDI</option>
-                </select>
-
+                <div class="filter">
+                  <label for="s2id_autogen2" class="h5 control-label">Select Document Code</label>
+                  <select class="select2 form-control" tabindex="-1" title="" name="documentcode" id="documentcodeID">
+                    <option value="">Please choose a document code</option>
+                    <option value="RXCTIN">INTERFERENCE COMMUNICATION: INITIAL MEMO:RXCTIN</option>
+                    <option value="RDIN">RX - DECISION STAYING REEXAM IN FAVOR OF INTERFERENCE:RDIN</option>
+                    <option value="M327-D">PUB OTHER MISCELLANEOUS COMMUNICATION TO APPLICANT:M327-D</option>
+                    <option value="CTNF">NON-FINAL REJECTION:CTNF</option>
+                    <option value="CNTA">ALLOWABILITY NOTICE:CNTA</option>
+                    <option value="CTFR">FINAL REJECTION:CTFR</option>
+                    <option value="CNOA">CORRECTED NOTICE OF ALLOWABILITY:CNOA</option>
+                    <option value="N271">RESPONSE TO AMENDMENT UNDER RULE 312:N271</option>
+                    <option value="REXD">RX - EX PARTE REEXAM ORDER - DENIED:REXD</option>
+                    <option value="EX.R">REASONS FOR ALLOWANCE:EX.R</option>
+                    <option value="RTDE">RX - PETITION DECISION - DENIED:RTDE</option>
+                    <option value="INTNO">INTERFERENCE NOTIFICATION TO PATENTEE RULE 607:INTNO</option>
+                    <option value="L.SI">SUSPENSION - INTERFERENCE IN ANOTHER CASE:L.SI</option>
+                    <option value="RXBPAI">REEXAM FORWARDED TO BOARD OF PATENT APPEALS AND INTERFERENCES:RXBPAI</option>
+                    <option value="RXSRXI">DECISION STAYING REEXAM PROCEEDING IN FAVOR OF INTERFERENCE PROCEEDING:RXSRXI</option>
+                    <option value="CTMS">MISCELLANEOUS ACTION WITH SSP:CTMS</option>
+                    <option value="M327">MISCELLANEOUS COMMUNICATION TO APPLICANT - NO ACTION COUNT:M327</option>
+                    <option value="M327-E">BOA MISCELLANEOUS COMMUNICATION TO APPLICANT:M327-E</option>
+                    <option value="P132">MISCELLANEOUS COMMUNICATION:P132</option>
+                    <option value="R327">RX - MISCELLANEOUS COMMUNICATION TO APPLICANT:R327</option>
+                    <option value="RXM327">MISCELLANEOUS COMMUNICATION TO APPLICANT:RXM327</option>
+                    <option value="RXMISC">MISCELLANEOUS ACTION MAILED:RXMISC</option>
+                    <option value="RXMMIS">MISCELLANEOUS LETTER MAILED:RXMMIS</option>
+                    <option value="SEMI">SE - MISCELLANEOUS DECISION/OFFICE NOTICE IN SE:SEMI</option>
+                    <option value="RTGR">RX - PETITION DECISION - GRANTED:RTGR</option>
+                    <option value="RTDI">RX - PETITION DECISION - DISMISSED:RTDI</option>
+                  </select>
+                </div>
+                <div class="filter">
+                  <div class="h5" tabindex="0">Art Unit</div>
+                  <div class="form-group">
+                    <input type="text" name="art_unit" aria-label="Search Art Unit Number" title="Search Art Unit Number" class="form-control" placeholder="Search Art Unit Number" value="{{artUnit}}">
+                    <div style="margin-bottom: 0;" class="help-block">
+                      <b><i>Example: Search for Art Unit number <code>3669~2</code></i></b>
+                    </div>
+                  </div>
+                </div>
                 <span class="input-group-btn">
                   <button class="btn btn-primary" style="z-index: 1;">Refine Search</button>
                 </span>
               </form>
-              {{/if}}
-              {{#unless accessOK}}
-              This Search engine is for authorized users only.
-              <hr> For access, please contact Thomas Beach
-              {{/unless}}
-          </div>
-          <div class="main-wrapper row-grid">
-          <div class="row-grid">
-            <div class="main-content col">
-              <div class="panel-body">
-                <div class="results-header">
-                  <a tabindex="-1" id="searchResults"></a>
-                  <a href="#void" class="link-sidebar"><i class="icon icon-columns"></i>Refine</a>
-                  <div class="pg-actions clearfix">
-                    <div class="row">
-                      {{#if term}}<span> Search Term: <span class="label label-success subtle">{{term}}</span> </span>
-                      {{/if}}
-
-                      {{#if artUnit}}<span> Art Unit: <span class="label label-success subtle">{{artUnit}}</span></span>
-                      {{/if}}
-                      {{#if documentcode}}
-                      <span> Document Code: </span><span class="label label-success subtle">{{documentcode}}</span>
-                      {{/if}}
-                      {{#if total}}
-                        <br>
-                        <span class="pull-left margin-top-0">{{total}} results took {{took}} ms</span>
-                        <span><a href="javascript:void(0);" onclick="resizeText(1)" id="plustext"> [+] Make results bigger</a> | <a href="javascript:void(0);" onclick="resizeText(-1)" id="minustext">[-] Make results smaller</a></span>
-                      {{/if}}
-
-                      <div class="btn-pgActions btn-group">
-                        {{#if term}}
-                          <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default dropdown-toggle" id="btn-pgActions">Download <span class="caret"></span></button>
-                          <ul aria-labelledby="btn-pgActions" class="dropdown-menu">
-                            <li role="presentation"><a target="_BLANK" href="/download?q={{term}}">Download CSV</a></li>
-                          </ul>
+            </div>
+            <div class="row-grid">
+              <div class="main-content col">
+                <div class="panel-body">
+                  <div class="results-header">
+                    <a tabindex="-1" id="searchResults"></a>
+                    <a href="#void" class="link-sidebar"><i class="icon icon-columns"></i>Refine</a>
+                    <div class="pg-actions clearfix">
+                      <div class="row">
+                        {{#if term}}<span> Search Term: <span class="label label-success subtle">{{term}}</span> </span>
                         {{/if}}
+                        {{#if artUnit}}<span> Art Unit: <span class="label label-success subtle">{{artUnit}}</span></span>
+                        {{/if}}
+                        {{#if documentcode}}<span> Document Code: </span><span class="label label-success subtle">{{documentcode}}</span>
+                        {{/if}}
+                        {{#if fromdate}}<span> Date Range: </span><span class="label label-success subtle">{{fromdate}}</span>
+                        {{/if}}
+                        {{#if total}}
+                          <br>
+                          <span class="pull-left margin-top-0">{{total}} results took {{took}} ms</span>
+                          <span><a href="javascript:void(0);" onclick="resizeText(1)" id="plustext"> [+] Make results bigger</a> | <a href="javascript:void(0);" onclick="resizeText(-1)" id="minustext">[-] Make results smaller</a></span>
+                        {{/if}}
+
+                        <div class="btn-pgActions btn-group">
+                          {{#if term}}
+                            <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default dropdown-toggle" id="btn-pgActions">Download <span class="caret"></span></button>
+                            <ul aria-labelledby="btn-pgActions" class="dropdown-menu">
+                              <li role="presentation"><a target="_BLANK" href="/download?q={{term}}">Download CSV</a></li>
+                            </ul>
+                          {{/if}}
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-                <div class="table--searchResults js-tableSwitch">
-                  <div class="table-responsive">
-                    {{{body}}}
+                  <div class="table--searchResults js-tableSwitch">
+                    <div class="table-responsive">
+                      {{{body}}}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/searchtool/server/views/layout.hbs
+++ b/searchtool/server/views/layout.hbs
@@ -33,6 +33,9 @@
           <li>
             <a href="/help">Help</a>
           </li>
+          <li>
+            <a href="/newsearch">Search</a>
+          </li>
         </ul>
         <div class="navbar-collapse collapse" id="navbar">
           <ul class="nav navbar-nav navbar-right">
@@ -105,39 +108,39 @@
                 <div class="filter">
                   <label for="s2id_autogen2" class="h5 control-label">Select Document Code</label>
                   <select class="select2 form-control" tabindex="-1" title="" name="documentcode" id="documentcodeID">
-                    <option value="">Please choose a document code</option>
-                    <option value="RXCTIN">INTERFERENCE COMMUNICATION: INITIAL MEMO:RXCTIN</option>
-                    <option value="RDIN">RX - DECISION STAYING REEXAM IN FAVOR OF INTERFERENCE:RDIN</option>
-                    <option value="M327-D">PUB OTHER MISCELLANEOUS COMMUNICATION TO APPLICANT:M327-D</option>
-                    <option value="CTNF">NON-FINAL REJECTION:CTNF</option>
-                    <option value="CNTA">ALLOWABILITY NOTICE:CNTA</option>
-                    <option value="CTFR">FINAL REJECTION:CTFR</option>
-                    <option value="CNOA">CORRECTED NOTICE OF ALLOWABILITY:CNOA</option>
-                    <option value="N271">RESPONSE TO AMENDMENT UNDER RULE 312:N271</option>
-                    <option value="REXD">RX - EX PARTE REEXAM ORDER - DENIED:REXD</option>
-                    <option value="EX.R">REASONS FOR ALLOWANCE:EX.R</option>
-                    <option value="RTDE">RX - PETITION DECISION - DENIED:RTDE</option>
-                    <option value="INTNO">INTERFERENCE NOTIFICATION TO PATENTEE RULE 607:INTNO</option>
-                    <option value="L.SI">SUSPENSION - INTERFERENCE IN ANOTHER CASE:L.SI</option>
-                    <option value="RXBPAI">REEXAM FORWARDED TO BOARD OF PATENT APPEALS AND INTERFERENCES:RXBPAI</option>
-                    <option value="RXSRXI">DECISION STAYING REEXAM PROCEEDING IN FAVOR OF INTERFERENCE PROCEEDING:RXSRXI</option>
-                    <option value="CTMS">MISCELLANEOUS ACTION WITH SSP:CTMS</option>
-                    <option value="M327">MISCELLANEOUS COMMUNICATION TO APPLICANT - NO ACTION COUNT:M327</option>
-                    <option value="M327-E">BOA MISCELLANEOUS COMMUNICATION TO APPLICANT:M327-E</option>
-                    <option value="P132">MISCELLANEOUS COMMUNICATION:P132</option>
-                    <option value="R327">RX - MISCELLANEOUS COMMUNICATION TO APPLICANT:R327</option>
-                    <option value="RXM327">MISCELLANEOUS COMMUNICATION TO APPLICANT:RXM327</option>
-                    <option value="RXMISC">MISCELLANEOUS ACTION MAILED:RXMISC</option>
-                    <option value="RXMMIS">MISCELLANEOUS LETTER MAILED:RXMMIS</option>
-                    <option value="SEMI">SE - MISCELLANEOUS DECISION/OFFICE NOTICE IN SE:SEMI</option>
-                    <option value="RTGR">RX - PETITION DECISION - GRANTED:RTGR</option>
-                    <option value="RTDI">RX - PETITION DECISION - DISMISSED:RTDI</option>
+                    <option selected disabled>Choose here</option>
+                    <option value="RXCTIN">INTERFERENCE COMMUNICATION: INITIAL MEMO</option>
+                    <option value="RDIN">RX - DECISION STAYING REEXAM IN FAVOR OF INTERFERENCE</option>
+                    <option value="M327-D">PUB OTHER MISCELLANEOUS COMMUNICATION TO APPLICANT</option>
+                    <option value="CTNF">NON-FINAL REJECTION</option>
+                    <option value="CNTA">ALLOWABILITY NOTICE</option>
+                    <option value="CTFR">FINAL REJECTION</option>
+                    <option value="CNOA">CORRECTED NOTICE OF ALLOWABILITY</option>
+                    <option value="N271">RESPONSE TO AMENDMENT UNDER RULE 312</option>
+                    <option value="REXD">RX - EX PARTE REEXAM ORDER - DENIED</option>
+                    <option value="EX.R">REASONS FOR ALLOWANCE</option>
+                    <option value="RTDE">RX - PETITION DECISION - DENIED</option>
+                    <option value="INTNO">INTERFERENCE NOTIFICATION TO PATENTEE RULE 607</option>
+                    <option value="L.SI">SUSPENSION - INTERFERENCE IN ANOTHER CASE</option>
+                    <option value="RXBPAI">REEXAM FORWARDED TO BOARD OF PATENT APPEALS AND INTERFERENCES</option>
+                    <option value="RXSRXI">DECISION STAYING REEXAM PROCEEDING IN FAVOR OF INTERFERENCE PROCEEDING</option>
+                    <option value="CTMS">MISCELLANEOUS ACTION WITH SSP</option>
+                    <option value="M327">MISCELLANEOUS COMMUNICATION TO APPLICANT - NO ACTION COUNT</option>
+                    <option value="M327-E">BOA MISCELLANEOUS COMMUNICATION TO APPLICANT</option>
+                    <option value="P132">MISCELLANEOUS COMMUNICATION</option>
+                    <option value="R327">RX - MISCELLANEOUS COMMUNICATION TO APPLICANT</option>
+                    <option value="RXM327">MISCELLANEOUS COMMUNICATION TO APPLICANT</option>
+                    <option value="RXMISC">MISCELLANEOUS ACTION MAILED</option>
+                    <option value="RXMMIS">MISCELLANEOUS LETTER MAILED</option>
+                    <option value="SEMI">SE - MISCELLANEOUS DECISION/OFFICE NOTICE IN SE</option>
+                    <option value="RTGR">RX - PETITION DECISION - GRANTED</option>
+                    <option value="RTDI">RX - PETITION DECISION - DISMISSED</option>
                   </select>
                 </div>
                 <div class="filter">
                   <div class="h5" tabindex="0">Art Unit</div>
                   <div class="form-group">
-                    <input type="text" name="art_unit" aria-label="Search Art Unit Number" title="Search Art Unit Number" class="form-control" placeholder="Search Art Unit Number" value="{{artUnit}}">
+                    <input type="text" name="art_unit" aria-label="Search Art Unit Number" title="Search Art Unit Number" class="form-control" placeholder="Search Art Unit Number" value="{{artunit}}">
                     <div style="margin-bottom: 0;" class="help-block">
                       <b><i>Example: Search for Art Unit number <code>3669~2</code></i></b>
                     </div>
@@ -158,11 +161,11 @@
                       <div class="row">
                         {{#if term}}<span> Search Term: <span class="label label-success subtle">{{term}}</span> </span>
                         {{/if}}
-                        {{#if artUnit}}<span> Art Unit: <span class="label label-success subtle">{{artUnit}}</span></span>
+                        {{#if artunit}}<span> Art Unit: <span class="label label-success subtle">{{artunit}}</span></span>
                         {{/if}}
                         {{#if documentcode}}<span> Document Code: </span><span class="label label-success subtle">{{documentcode}}</span>
                         {{/if}}
-                        {{#if fromdate}}<span> Date Range: </span><span class="label label-success subtle">{{fromdate}}</span>
+                        {{#if fromdate}}<span> Date Range: </span><span class="label label-success subtle">{{fromdate}} - {{todate}}</span>
                         {{/if}}
                         {{#if total}}
                           <br>

--- a/searchtool/server/views/layout.hbs
+++ b/searchtool/server/views/layout.hbs
@@ -5,7 +5,11 @@
   <meta charset="utf-8">
   <title>Office Action Search</title>
   <meta name="description" content="Office Action Search">
-  <link rel="shortcut icon" href="/bower_components/designpatterns/generated/favicon.ico">
+  <meta name="keywords" content="office actions">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+  <meta name="theme-color" content="#004c97">
+  <meta property="og:title" content="Customize search results">
+  <meta property="og:description" content="">  <link rel="shortcut icon" href="/bower_components/designpatterns/generated/favicon.ico">
   <link href="/bower_components/designpatterns/generated/styles/vendor.css" rel="stylesheet" />
   <link href="/bower_components/designpatterns/generated/styles/main.css" rel="stylesheet" />
   <link href="/bower_components/designpatterns/generated/styles/appDemo.min.css" rel="stylesheet" />
@@ -22,10 +26,13 @@
     <nav class="navbar navbar-inverse">
       <div class="container-fluid container--full">
         <div class="navbar-header">
-          <button aria-controls="navbar" aria-expanded="false" data-target="#navbar" data-toggle="collapse" class="navbar-toggle collapsed" type="button">
-            <span class="sr-only">Toggle navigation</span>
-          </button>
+        <a href="/designpatterns/index.html" class="navbar-brand"><strong>USPTO</strong> <span class="light">Patent Quality Search Tool</span></a>
         </div>
+        <ul class="nav navbar-nav">
+          <li>
+            <a href="/help">Help</a>
+          </li>
+        </ul>
         <div class="navbar-collapse collapse" id="navbar">
           <ul class="nav navbar-nav navbar-right">
             <li class="dropdown">
@@ -45,40 +52,19 @@
 
   <main class="wrapper container-fluid container--full">
     <div class="row-grid">
-      <nav class="pane-left keyline-bottom">
-        <a tabindex="-1" id="contentNav"></a>
-        <div class="close-sidebar keyline-bottom clearfix">
-          <button type="button" class="btn-closeSidebar pull-right btn btn-sm btn-default btn-hover"><i class="icon icon-angle-double-left"></i> Close</button>
-        </div>
-        <ul role="tab-list" class="nav nav-stacked">
-          <li tabindex="0" class="category" role="presentation"><i class="icon icon-dashboard"></i> Dashboards</li>
-          <li role="presentation"><a href="#" role="tab">Systems summary</a></li>
-          <li role="presentation"><a href="#" role="tab">System A</a></li>
-          <li role="presentation"><a href="#" role="tab">System B</a></li>
-          <li role="presentation"><a href="#" role="tab">System C</a></li>
-          <li tabindex="0" class="category" role="presentation"><i class="icon icon-bar-chart"></i> Reports</li>
-          <li role="presentation"><a href="#" role="tab">Fees and transactions</a></li>
-          <li role="presentation"><a href="#" role="tab">Trends</a></li>
-          <li role="presentation"><a href="#" role="tab">Disposition</a></li>
-          <li role="presentation"><a href="#" role="tab">Custom</a></li>
-        </ul>
-      </nav>
       <div class="pane-center col">
         <div class="panel--page panel panel-default">
           <a tabindex="-1" id="search"></a>
           <div class="header keyline-bottom">
-            {{#unless accessOK}}
-              This Search engine is for Authorized users only.
-              <hr> For access, please contact Thomas Beach
-            {{/unless}}
             {{#if accessOK}}
               <form role="form" action="/newsearch" class="padding-top-2 padding-right-2 padding-bottom-2">
                 <h2 class="margin-top-0">Patent Data Search</h2>
+                <div class="form-group col-sm-5">
                 <div class="input-search input-group">
                   <input type="text" name="q" value="{{#if term}}{{term}}{{/if}}" aria-label="Search all fields" title="Search all fields" class="form-control" placeholder="Search all fields" id="txt-find">
                   <span class="input-group-btn">
-                  <button class="btn btn-primary"><i class="icon icon-inverse icon-search"></i></button>
-                </span>
+                    <button class="btn btn-primary"><i class="icon icon-inverse icon-search"></i></button>
+                  </span>
                 </div>
                 <label class="radio-inline">
                   <input type="radio" name="dataset" id="inlineRadio1" value="oa" {{#unless ptab}} checked {{/unless}}> Office Actions
@@ -87,48 +73,34 @@
                   <input type="radio" name="dataset" id="inlineRadio2" value="ptab" {{#if ptab}} checked {{/if}}> PTAB
                 </label>
                 <div style="margin-bottom: 0;" class="help-block">
-                  <b><i>Examples: Search for law 112(f) ..... <code>"112\(f\)"</code>  or search for Art Unit .. <code>"Art Unit 3669"~2</code>  </i></b>
+                  <b><i>Examples: Search for law 112(f)...<code>"112\(f\)"</code> or for Art Unit... <code>"Art Unit 3669"~2</code>  </i></b>
                 </div>
-                <div class="help-button">
-                  <a href="/help" class="btn btn-primary">Help</a>
+              </div>
+                <div class="form-group col-sm-1">
+                  <span class="input-icon icon icon-calendar-o"></span>
+                  <input name="fromdate" type="text" placeholder="Start" class="datepicker form-control" value="{{fromdate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="Start date" aria-label="Start date">
                 </div>
-          </div>
-          <div class="main-wrapper row-grid">
-            <div class="app-sidebar filters keyline-right">
-              <a tabindex="-1" id="filters"></a>
-              <div class="close-sidebar keyline-bottom clearfix">
-                <button class="btn-closeSidebar pull-right btn btn-sm btn-default btn-hover"><i class="icon icon-angle-double-left"></i> Close</button>
-              </div>
-              <div class="filter-heading">
-                <span tabindex="0" class="h4">Refine by</span> <a class="filters-clear" href="">Clear</a>
-              </div>
-              <div class="filter-list">
-                <div class="filter-group-content">
-                  <div class="row">
-                    <div class="form-group col-sm-6">
-                      <span class="input-icon icon icon-calendar-o"></span>
-                      <input name="fromdate" type="text" placeholder="Start" class="datepicker form-control" value="{{fromdate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="Start date" aria-label="Start date">
-                    </div>
-                    <div class="form-group col-sm-6">
-                      <span class="input-icon icon icon-calendar-o"></span>
-                      <input name="todate" type="text" placeholder="End" class="datepicker form-control" value="{{todate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="End date" aria-label="End date">
-                    </div>
-                    <div class="form-group col-sm-6">
-                      <input type="text" name="art_unit" aria-label="Search Art Unit Number" title="Search Art Unit Number" class="form-control" placeholder="Search Art Unit Number" value="{{#if artUnit}} {{artUnit}}{{/if}}">
-                      <span>Please use 4-6 digit number</span>
-                    </div>
+                <div class="form-group col-sm-1">
+                  <span class="input-icon icon icon-calendar-o"></span>
+                  <input name="todate" type="text" placeholder="End" class="datepicker form-control" value="{{todate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="End date" aria-label="End date">
+                </div>
+                <div class="form-group col-sm-2">
+                  <input type="text" name="art_unit" aria-label="Search Art Unit Number" title="Search Art Unit Number" class="form-control" placeholder="Search Art Unit Number" value="{{#if artUnit}}{{artUnit}}{{/if}}">
+                  <div style="margin-bottom: 0;" class="help-block">
+                    <b><i>Example: Search for Art Unit number <code>3669~2</code></i></b>
                   </div>
                 </div>
-              </div>
-              <div class="input-search input-group" style="margin-left: 1em;">
                 <span class="input-group-btn">
                   <button class="btn btn-primary" style="z-index: 1;">Refine Search</button>
                 </span>
-              </div>
               </form>
               {{/if}}
-            </div>
+              {{#unless accessOK}}
+              This Search engine is for authorized users only.
+              <hr> For access, please contact Thomas Beach
+              {{/unless}}
           </div>
+          <div class="main-wrapper row-grid">
           <div class="row-grid">
             <div class="main-content col">
               <div class="panel-body">

--- a/searchtool/server/views/layout.hbs
+++ b/searchtool/server/views/layout.hbs
@@ -57,9 +57,9 @@
     <div class="row-grid">
       <div class="pane-center col">
         <div class="panel--page panel panel-default">
+          {{#if accessOK}}
           <a tabindex="-1" id="search"></a>
           <div class="header keyline-bottom">
-            {{#if accessOK}}
               <form role="form" action="/newsearch" class="padding-top-2 padding-right-2 padding-bottom-2">
                 <h2 class="margin-top-0">Patent Data Search</h2>
                 <div class="input-search input-group">
@@ -75,16 +75,19 @@
                   <input type="radio" name="dataset" id="inlineRadio2" value="ptab" {{#if ptab}} checked {{/if}}> PTAB
                 </label>
                 <div style="margin-bottom: 0;" class="help-block">
-                  <b><i>Examples: Search for law 112(f)...<code>"112\(f\)"</code> or for Art Unit... <code>"Art Unit 3669"~2</code>  </i></b>
+                  <b><i>Examples: Search for law 112(f):<code>"112\(f\)"</code> or for Art Unit: <code>"Art Unit 3669"~2</code>  </i></b>
                 </div>
               </form>
-            {{/if}}
+          </div>
+          {{/if}}
+          <div class="main-wrapper row-grid">
             {{#unless accessOK}}
+            <div class="app-sidebar filters keyline-right">
               This Search engine is for authorized users only.
               <hr> For access, please contact Thomas Beach
+            </div>
             {{/unless}}
-          </div>
-          <div class="main-wrapper row-grid">
+            {{#if accessOK}}
             <div class="app-sidebar filters keyline-right">
               <a tabindex="-1" id="filters"></a>
               <div class="filter-heading">
@@ -153,6 +156,7 @@
                 </span>
               </form>
             </div>
+            {{/if}}
             <div class="row-grid">
               <div class="main-content col">
                 <div class="panel-body">

--- a/searchtool/server/views/layout.hbs
+++ b/searchtool/server/views/layout.hbs
@@ -68,15 +68,15 @@
                   <button class="btn btn-primary"><i class="icon icon-inverse icon-search"></i></button>
                 </span>
                 </div>
+                <div style="margin-bottom: 0;" class="help-block">
+                  <b><i>Examples: Search for law 112(f):<code>"112\(f\)"</code> or for Art Unit: <code>"Art Unit 3669"~2</code>  </i></b>
+                </div>
                 <label class="radio-inline">
                   <input type="radio" name="dataset" id="inlineRadio1" value="oa" {{#unless ptab}} checked {{/unless}}> Office Actions
                 </label>
                 <label class="radio-inline">
                   <input type="radio" name="dataset" id="inlineRadio2" value="ptab" {{#if ptab}} checked {{/if}}> PTAB
                 </label>
-                <div style="margin-bottom: 0;" class="help-block">
-                  <b><i>Examples: Search for law 112(f):<code>"112\(f\)"</code> or for Art Unit: <code>"Art Unit 3669"~2</code>  </i></b>
-                </div>
               </form>
           </div>
           {{/if}}

--- a/searchtool/server/views/layout.hbs
+++ b/searchtool/server/views/layout.hbs
@@ -88,10 +88,12 @@
             <div class="app-sidebar filters keyline-right">
               <a tabindex="-1" id="filters"></a>
               <div class="filter-heading">
-                <span tabindex="0" class="h4">Refine by</span> <a class="filters-clear" href="">Clear</a>
+                <span tabindex="0" class="h4">Refine by</span> <a class="filters-clear" href="/newsearch">Clear</a>
               </div>
               <form class="filters-flat js-filterSwitch" role="form" action="/newsearch">
                 <div class="filter hide">
+                  <input type="radio" name="dataset" id="inlineRadio1" value="oa" {{#unless ptab}} checked {{/unless}}>
+                  <input type="radio" name="dataset" id="inlineRadio2" value="ptab" {{#if ptab}} checked {{/if}}> PTAB
                   <input type="text" name="q" value="{{term}}" aria-label="Search all fields" title="Search all fields" class="form-control hide" placeholder="Search all fields" id="txt-find">
                 </div>
                 <div class="filter">
@@ -199,7 +201,7 @@
   </main>
   <script src="/bower_components/designpatterns/generated/scripts/vendor.js"></script>
   <script src="/bower_components/designpatterns/generated/scripts/plugins.js"></script>
-  <script src="https://components.uspto.gov/js/ais/2-4-pattern-library.js"></script>
+  <!-- <script src="https://components.uspto.gov/js/ais/2-4-pattern-library.js"></script> -->
   <script src="/bower_components/designpatterns/generated/scripts/appDemo.js"></script>
   <script src="/client/scripts/script.js"></script>
 </body>

--- a/searchtool/server/views/layout.hbs
+++ b/searchtool/server/views/layout.hbs
@@ -3,44 +3,16 @@
 
 <head>
   <meta charset="utf-8">
-
   <title>Office Action Search</title>
-
   <meta name="description" content="Office Action Search">
-  <meta name="keywords" content="office actions">
-
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
-  <meta name="theme-color" content="#004c97">
-
-  <meta property="og:title" content="Customize search results">
-  <meta property="og:description" content="">
-
   <link rel="shortcut icon" href="/bower_components/designpatterns/generated/favicon.ico">
-
-  <!--[if lte IE 9]>
-            <script src="/bower_components/designpatterns/generated/vendor/matchMedia/matchMedia.js"></script>
-            <script src="/bower_components/designpatterns/generated/vendor/html5shiv/html5shiv.min.js"></script>
-        <![endif]-->
-
   <link href="/bower_components/designpatterns/generated/styles/vendor.css" rel="stylesheet" />
   <link href="/bower_components/designpatterns/generated/styles/main.css" rel="stylesheet" />
   <link href="/bower_components/designpatterns/generated/styles/appDemo.min.css" rel="stylesheet" />
   <link rel="stylesheet" type="text/css" href="/client/styles/layout_custom.css">
-  <style>
-    /* fix for IE transparent scroll bar */
-
-    @-ms-viewport {
-      width: auto !important;
-    }
-  </style>
 </head>
 
 <body class="search-results">
-  <!--[if lt IE 9]>
-        <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-    <![endif]-->
-
-
   <div class="skipLinks alert-info">
     <a class="sr-only focusable" href="#search">Skip to search</a>
     <a class="sr-only focusable" href="#searchResults">Skip to search results</a>
@@ -52,16 +24,10 @@
         <div class="navbar-header">
           <button aria-controls="navbar" aria-expanded="false" data-target="#navbar" data-toggle="collapse" class="navbar-toggle collapsed" type="button">
             <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
           </button>
-          <!-- <h1 class="margin-top-0"><a class="navbar-brand" href="dashboard.html">
-                    <span class="uspto-header__top__logo uspto-logo-svg margin-right-2"></span> Application Monitor <small>DEMO</small></a></h1> -->
         </div>
         <div class="navbar-collapse collapse" id="navbar">
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="#" data-toggle="tooltip" data-placement="left" title="Application alerts"><i class="icon icon-warning icon-inverse"></i><span class="ex-header--icon-badge">2</span></a></li>
             <li class="dropdown">
               <a aria-expanded="false" aria-haspopup="true" role="button" data-toggle="dropdown" class="dropdown-toggle" href="#"><i class="icon icon-user margin-right-1 icon-inverse"></i>{{#if email}} {{email}} {{/if}}<span class="caret"></span></a>
               <ul class="dropdown-menu">
@@ -75,9 +41,7 @@
         </div>
       </div>
     </nav>
-
   </header>
-
 
   <main class="wrapper container-fluid container--full">
     <div class="row-grid">
@@ -99,685 +63,119 @@
           <li role="presentation"><a href="#" role="tab">Custom</a></li>
         </ul>
       </nav>
-
       <div class="pane-center col">
         <div class="panel--page panel panel-default">
           <a tabindex="-1" id="search"></a>
           <div class="header keyline-bottom">
-            <form role="form" action="/newsearch" class="padding-top-2 padding-right-2 padding-bottom-2">
-              <h2 class="margin-top-0">Patent Data Search</h2>
-              {{#if accessOK}}
-              <div class="input-search input-group">
-                <input type="text" name="q" value="{{#if term}}{{term}}{{/if}}" aria-label="Search all fields" title="Search all fields" class="form-control" placeholder="Search all fields" id="txt-find">
-                <span class="input-group-btn">
+            {{#unless accessOK}}
+              This Search engine is for Authorized users only.
+              <hr> For access, please contact Thomas Beach
+            {{/unless}}
+            {{#if accessOK}}
+              <form role="form" action="/newsearch" class="padding-top-2 padding-right-2 padding-bottom-2">
+                <h2 class="margin-top-0">Patent Data Search</h2>
+                <div class="input-search input-group">
+                  <input type="text" name="q" value="{{#if term}}{{term}}{{/if}}" aria-label="Search all fields" title="Search all fields" class="form-control" placeholder="Search all fields" id="txt-find">
+                  <span class="input-group-btn">
                   <button class="btn btn-primary"><i class="icon icon-inverse icon-search"></i></button>
                 </span>
-              </div>
-              <label class="radio-inline">
-                <input type="radio" name="dataset" id="inlineRadio1" value="oa" {{#unless ptab}}checked{{/unless}}> Office Actions
-              </label>
-              <label class="radio-inline">
-                <input type="radio" name="dataset" id="inlineRadio2" value="ptab" {{#if ptab}}checked{{/if}}> PTAB
-              </label>
-              <div style="margin-bottom: 0;" class="help-block">
-                <b><i>Examples: Search for law 112(f) ..... <code>"112\(f\)"</code>  or search for Art Unit .. <code>"Art Unit 3669"~2</code>  </i></b>
-                <!-- <a href="#void">Show advanced search</a> -->
-              </div>
-
-              <div class="help-button">
-                <a href="/help" class="btn btn-primary">Help</a>
-              </div>
-
-              {{/if}}
-
-
-              <div class="tabs-results tabs-responsive btn-group hide">
-                <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default dropdown-toggle hide" type="button">
-                  All<span class="badge">100</span> <span class="caret"></span>
-                </button>
-                <ul class="nav nav-tabs">
-                  <li class="active"><a data-toggle="tab" role="tab" href="#"><span>All</span><span class="badge">100</span></a></li>
-                  <li><a role="tab" data-toggle="tab" href="#"><span>Unassigned</span><span class="badge">45</span></a></li>
-                  <li><a role="tab" data-toggle="tab" href="#"><span>Partially assigned</span><span class="badge">34</span></a></li>
-                  <li><a role="tab" data-toggle="tab" href="#"><span>Fully assigned</span><span class="badge">3</span></a></li>
-                </ul>
-              </div>
+                </div>
+                <label class="radio-inline">
+                  <input type="radio" name="dataset" id="inlineRadio1" value="oa" {{#unless ptab}} checked {{/unless}}> Office Actions
+                </label>
+                <label class="radio-inline">
+                  <input type="radio" name="dataset" id="inlineRadio2" value="ptab" {{#if ptab}} checked {{/if}}> PTAB
+                </label>
+                <div style="margin-bottom: 0;" class="help-block">
+                  <b><i>Examples: Search for law 112(f) ..... <code>"112\(f\)"</code>  or search for Art Unit .. <code>"Art Unit 3669"~2</code>  </i></b>
+                </div>
+                <div class="help-button">
+                  <a href="/help" class="btn btn-primary">Help</a>
+                </div>
           </div>
           <div class="main-wrapper row-grid">
             <div class="app-sidebar filters keyline-right">
-              {{#unless accessOK}}
-              This Search engine is for Authorized users only.
-              <hr> For access, please contact Thomas Beach
-              {{/unless}}
               <a tabindex="-1" id="filters"></a>
               <div class="close-sidebar keyline-bottom clearfix">
                 <button class="btn-closeSidebar pull-right btn btn-sm btn-default btn-hover"><i class="icon icon-angle-double-left"></i> Close</button>
               </div>
-              {{#if accessOK}}
-                  <div class="filter-heading">
-                    <span tabindex="0" class="h4">Refine by</span> <a class="filters-clear" href="">Clear</a>
-                  </div>
-              {{/if}}
-
-              <!--  <form class="filters-accordion js-filterSwitch" role="form"> -->
-              <!-- <div class="h5" tabindex="0">Assignment</div> -->
+              <div class="filter-heading">
+                <span tabindex="0" class="h4">Refine by</span> <a class="filters-clear" href="">Clear</a>
+              </div>
               <div class="filter-list">
-                <!--    <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#2filterGroup8">Filing year <i class="icon icon-angle-right pull-right"></i></a>
-        <div id="2filterGroup8" class="collapse">
-            <div class="filter-group-content">
-                <div class="form-group">
-                    <ul class="list-unstyled">
-                        <li><a href="">2014</a></li>
-                        <li><a href="">2013</a></li>
-                        <li><a href="">2012</a></li>
-                        <li><a href="">2011</a></li>
-                    </ul>
+                <div class="filter-group-content">
+                  <div class="row">
+                    <div class="form-group col-sm-6">
+                      <span class="input-icon icon icon-calendar-o"></span>
+                      <input name="fromdate" type="text" placeholder="Start" class="datepicker form-control" value="{{fromdate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="Start date" aria-label="Start date">
+                    </div>
+                    <div class="form-group col-sm-6">
+                      <span class="input-icon icon icon-calendar-o"></span>
+                      <input name="todate" type="text" placeholder="End" class="datepicker form-control" value="{{todate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="End date" aria-label="End date">
+                    </div>
+                    <div class="form-group col-sm-6">
+                      <input type="text" name="art_unit" aria-label="Search Art Unit Number" title="Search Art Unit Number" class="form-control" placeholder="Search Art Unit Number" value="{{#if artUnit}} {{artUnit}}{{/if}}">
+                      <span>Please use 4-6 digit number</span>
+                    </div>
+                  </div>
                 </div>
+              </div>
+              <div class="input-search input-group" style="margin-left: 1em;">
+                <span class="input-group-btn">
+                  <button class="btn btn-primary" style="z-index: 1;">Refine Search</button>
+                </span>
+              </div>
+              </form>
+              {{/if}}
             </div>
-        </div> -->
-                {{#if accessOK}}
-                    <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#2filterGroup1"><i class="icon icon-angle-right pull-right"></i> Filing date range</a>
-                {{/if}}
-                <div id="2filterGroup1" class="collapse">
-                  <div class="filter-group-content">
+          </div>
+          <div class="row-grid">
+            <div class="main-content col">
+              <div class="panel-body">
+                <div class="results-header">
+                  <a tabindex="-1" id="searchResults"></a>
+                  <a href="#void" class="link-sidebar"><i class="icon icon-columns"></i>Refine</a>
+                  <div class="pg-actions clearfix">
                     <div class="row">
-                      <div class="form-group col-sm-6">
-                        <span class="input-icon icon icon-calendar-o"></span>
-                        <input name="fromdate" type="text" placeholder="Start" class="datepicker form-control" value="{{fromdate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="Start date" aria-label="Start date">
-                      </div>
-                      <div class="form-group col-sm-6">
-                        <span class="input-icon icon icon-calendar-o"></span>
-                        <input name="todate" type="text" placeholder="End" class="datepicker form-control" value="{{todate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="End date" aria-label="End date">
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                {{#if accessOK}}
-                
-              
-
-                <div>
-                  <input type="text" name="art_unit"  aria-label="Search Art Unit Number" title="Search Art Unit Number" class="form-control" placeholder="Search Art Unit Number" value="{{#if artUnit}} {{artUnit}}{{/if}}">
-                  <span>Please use 4-6 digit number</span>
-                </div>
-
-                <div class="input-search input-group" style="margin-left: 1em;">
-                  <span class="input-group-btn">
-                    <button class="btn btn-primary" style="z-index: 1;">Refine Search</button>
-                  </span>
-                </div>
-                {{/if}}
-                </form>
-                <!--  <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#2filterGroup2"><i class="icon icon-angle-right pull-right"></i> <span class="badge pull-right">1</span> Application type</a>
-        <div id="2filterGroup2" class="collapse">
-            <div class="filter-group-content">
-                <div class="form-group">
-                    <div class="checkbox">
-                        <label>
-                            <input checked type="checkbox">Assignment <span class="text-muted">(13)</span></label>
-                    </div>
-                    <div class="checkbox">
-                        <label>
-                            <input type="checkbox"> Change of name <span class="text-muted">(45)</span></label>
-                    </div>
-                    <div class="checkbox">
-                        <label>
-                            <input type="checkbox"> Trademark <span class="text-muted">(18)</span></label>
-                    </div>
-                    <div class="checkbox">
-                        <label>
-                            <input type="checkbox"> Certification <span class="text-muted">(32)</span></label>
-                    </div>
-                    <div class="checkbox">
-                        <label>
-                            <input type="checkbox"> Service <span class="text-muted">(43)</span></label>
-                    </div>
-                    <a href="#void">Show 12 more...</a>
-                </div>
-            </div>
-        </div>
-            <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#2filterGroup5"><i class="icon icon-angle-right pull-right"></i> Applicant</a>
-        <div id="2filterGroup5" class="collapse">
-            <div class="filter-group-content">
-                <div class="form-group">
-                    <div class="form-group">
-                        <ul class="list-unstyled">
-                            <li><a href="">JOHN SMITH ET AL</a></li>
-                            <li><a href="">JANE LLC</a></li>
-                            <li><a href="">JOHNSON CO</a></li>
-                            <li><a href="">INITECH</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="h5" tabindex="0">Assignee (Owner)</div>
-    <div class="filter-list">
-            <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#3filterGroup8">Assignee <i class="icon icon-angle-right pull-right"></i></a>
-        <div id="3filterGroup8" class="collapse">
-            <div class="filter-group-content">
-                <div class="form-group">
-                    <ul class="list-unstyled">
-                        <li><a href="">John Smith Et al.</a></li>
-                        <li><a href="">Jane LLC</a></li>
-                        <li><a href="">Johnson Co.</a></li>
-                        <li><a href="">Initech</a></li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-            <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#3filterGroup2"><i class="icon icon-angle-right pull-right"></i> Assignee country</a>
-        <div id="3filterGroup2" class="collapse">
-            <div class="filter-group-content">
-                <div class="form-group">
-                    <ul class="list-unstyled">
-                        <li><a href="">United States</a></li>
-                        <li><a href="">France</a></li>
-                        <li><a href="">Germany</a></li>
-                        <li><a href="">Hungary</a></li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-          <div class="padding-2">
-        <a id="supportInfo" tabindex="-1"></a>
-        <h3 class="margin-top-0">Help</h3>
-        <h4 class="h6 text-uppercase text-muted">Resources</h4>
-        <ul class="list-unstyled">
-            <li><a href="/help">Search query suggestions</a></li>
-        </ul>
-        <h4 class="h6 text-uppercase text-muted"><abbr title="Frequently Asked Questions">Faq</abbr></h4>
-        <ul class="list-unstyled">
-            <li><a href="">How many office actions are loaded?</a></li>
-            <li><a href="">When are updates applied?</a></li>
-        </ul>
-    </div>-
-    </div>
-<!-- </form> -->
-
-                <!-- <form class="filters-flat js-filterSwitch hide" role="form"> -->
-                <!--  <div class="filter">
-        <label for="s2id_autogen2" class="h5 control-label">Select year</label>
-        <select class="select2 form-control">
-            <option>2015</option>
-            <option>2014</option>
-            <option>2013</option>
-            <option>2012</option>
-        </select>
-    </div>
-    <div class="filter">
-        <div class="h5" tabindex="0">Filing date range</div>
-        <div class="form-group">
-            <span class="input-icon icon icon-calendar-o"></span>
-            <input type="text" placeholder="Start" class="datepicker form-control" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="Start date" aria-label="Start date">
-        </div>
-        <div class="form-group margin-bottom-0">
-            <span class="input-icon icon icon-calendar-o"></span>
-            <input type="text" placeholder="End" class="datepicker form-control" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="End date" aria-label="End date">
-        </div>
-    </div>
-    <div class="filter">
-        <div class="h5" tabindex="0">Applicant</div>
-        <label for="s2id_autogen4" class="control-label">Select applicant</label>
-        <select class="select2 form-control">
-            <option>All</option>
-            <option>JOHN SMITH ET AL</option>
-            <option>JANE LLC</option>
-            <option>JOHNSON CO</option>
-            <option>INITECH</option>
-        </select>
-    </div>
-    <div class="filter">
-        <div class="h5" tabindex="0">Application type</div>
-        <div class="form-group margin-bottom-0">
-            <div class="checkbox">
-                <label>
-                    <input checked type="checkbox">Assignment <span class="text-muted">(13)</span>
-                </label>
-            </div>
-            <div class="checkbox">
-                <label>
-                    <input type="checkbox"> Change of name <span class="text-muted">(45)</span>
-                </label>
-            </div>
-            <div class="checkbox">
-                <label>
-                    <input type="checkbox"> Trademark <span class="text-muted">(18)</span>
-                </label>
-            </div>
-            <div class="checkbox">
-                <label>
-                    <input type="checkbox"> Certification <span class="text-muted">(32)</span>
-                </label>
-            </div>
-            <div class="checkbox">
-                <label>
-                    <input type="checkbox"> Service <span class="text-muted">(43)</span>
-                </label>
-            </div>
-            <a href="#void">Show 12 more...</a>
-        </div>
-    </div>
-    <div class="filter">
-        <fieldset>
-            <legend class="h5 control-label">Assignee country</legend>
-            <div class="radio">
-                <label>
-                    <input type="radio" name="countryOpts" id="rdo-usa" value="" checked>United States<span class="help-block">(including all US territories)</span>
-                </label>
-            </div>
-            <div class="radio">
-                <label>
-                    <input type="radio" name="countryOpts" id="rdo-france" value="">France</label>
-            </div>
-            <div class="radio">
-                <label>
-                    <input type="radio" name="countryOpts" id="rdo-germany" value="">Germany</label>
-            </div>
-            <div class="radio">
-                <label>
-                    <input type="radio" name="countryOpts" id="rdo-gungary" value="">Hungary</label>
-            </div>
-        </fieldset>-->
-              </div>
-
-            </div>
-            <div class="row-grid">
-              <div class="main-content col">
-                <div class="panel-body">
-                  <div class="results-header">
-                    <a tabindex="-1" id="searchResults"></a>
-                    <a href="#void" class="link-sidebar"><i class="icon icon-columns"></i>Refine</a>
-                    <div class="pg-actions clearfix">
-                        <div class="row">
-                            {{#if term}}<span> Search Term: <span class="label label-success subtle">{{term}}</span> </span>{{/if}}
-
-                            {{#if artUnit}}<span> Art Unit: <span class="label label-success subtle">{{artUnit}}</span></span>{{/if}}
-
-                            {{#if total}}<br>
-                            <span class="pull-left margin-top-0">{{total}} results took {{took}} ms</span>
-                            <span><a href="javascript:void(0);" onclick="resizeText(1)" id="plustext"> [+] Make results bigger</a> | <a href="javascript:void(0);" onclick="resizeText(-1)" id="minustext">[-] Make results smaller</a></span>
-                            {{/if}}
-
-                          <div class="btn-pgActions btn-group">
-                            {{#if term}}
-                              <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default dropdown-toggle" id="btn-pgActions">Download <span class="caret"></span></button>
-                              <ul aria-labelledby="btn-pgActions" class="dropdown-menu">
-                                <!-- <li role="presentation"><a href="#">Print</a></li>
-                                                    <li class="divider" role="separator"></li> -->
-                                <!-- <li role="presentation"><a href="#">Download Excel</a></li> -->
-                                <li role="presentation"><a target="_BLANK" href="/download?q={{term}}">Download CSV</a></li>
-                              </ul>
-                              {{/if}}
-                          </div>
-                        </div>
-                    </div>
-                    <!-- <ul class="list-keywords list-unstyled margin-bottom-0">
-                                        <li tabindex="0" class="filter-value"><span>Application type: Service</span> <i class="icon icon-close icon-muted"></i></li>
-                                        <li tabindex="0" class="filter-value"><span>Applicant: JANE LLC</span> <i class="icon icon-close icon-muted"></i></li>
-                                    </ul> -->
-                  </div>
-                  <div class="table--searchResults js-tableSwitch">
-                  {{#if term}}
-                      <div class="table--actions row">
-                        <div class="col-xs-6">
-
-                        </div>
-                        <div class="col-xs-6">
-                          <!-- <div class="btn-group dropdown pull-right">
-                <button id="btn-displayOpts" type="button" class="btn-displayOpts btn btn-default dropdown-toggle" data-toggle="dropdown">10 per page <span class="caret"></span></button>
-                <ul class="dropdown-menu" role="menu" aria-labelledby="btn-displayOpts">
-                    <li role="presentation" class="dropdown-header">Show up to</li>
-                    <li role="presentation" class="active"><a role="menuitem" tabindex="-1" href="#">10 items</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1" href="#">25 items</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1" href="#">50 items</a></li>
-                    <li role="presentation"><a role="menuitem" tabindex="-1" href="#">100 items</a></li>
-                </ul>
-            </div> -->
-                        </div>
-                      </div>
+                      {{#if term}}<span> Search Term: <span class="label label-success subtle">{{term}}</span> </span>
                       {{/if}}
-                        <div class="table-responsive">
-                          {{{body}}}
-                        </div>
-                  </div>
-                  <div class="table--border js-tableSwitch hide">
-                    <div class="table--actions row">
-                      <div class="col-xs-12">
-                        <div class="btn-group dropdown">
-                          <button id="btn-displayOpts" type="button" class="btn-displayOpts btn btn-default dropdown-toggle" data-toggle="dropdown">10 per page <span class="caret"></span></button>
-                          <ul class="dropdown-menu" role="menu" aria-labelledby="btn-displayOpts">
-                            <li role="presentation" class="dropdown-header">Show up to</li>
-                            <li role="presentation" class="active"><a role="menuitem" tabindex="-1" href="#">10 items</a></li>
-                            <li role="presentation"><a role="menuitem" tabindex="-1" href="#">25 items</a></li>
-                            <li role="presentation"><a role="menuitem" tabindex="-1" href="#">50 items</a></li>
-                            <li role="presentation"><a role="menuitem" tabindex="-1" href="#">100 items</a></li>
+
+                      {{#if artUnit}}<span> Art Unit: <span class="label label-success subtle">{{artUnit}}</span></span>
+                      {{/if}}
+
+                      {{#if total}}
+                        <br>
+                        <span class="pull-left margin-top-0">{{total}} results took {{took}} ms</span>
+                        <span><a href="javascript:void(0);" onclick="resizeText(1)" id="plustext"> [+] Make results bigger</a> | <a href="javascript:void(0);" onclick="resizeText(-1)" id="minustext">[-] Make results smaller</a></span>
+                      {{/if}}
+
+                      <div class="btn-pgActions btn-group">
+                        {{#if term}}
+                          <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default dropdown-toggle" id="btn-pgActions">Download <span class="caret"></span></button>
+                          <ul aria-labelledby="btn-pgActions" class="dropdown-menu">
+                            <li role="presentation"><a target="_BLANK" href="/download?q={{term}}">Download CSV</a></li>
                           </ul>
-                        </div>
+                        {{/if}}
                       </div>
                     </div>
-                    <div class="table-responsive">
-                      <table class="table-bordered table table-sortable table-hover table-inverse">
-                        <thead>
-                          <tr>
-                            <th class="sortable"><a href="#void">Application
-                                    <abbr title="Number">#</abbr><span class="icon icon-sort icon-inverse"></span></a></th>
-                            <th class="sortable"><a href="#void">Docket
-                                    <abbr title="Number">#</abbr><span class="icon icon-sort icon-inverse"></span></a></th>
-                            <th>Title</th>
-                            <th class="sortable"><a href="#void">Filing Date<span class="icon icon-caret-down icon-inverse"></span></a></th>
-                            <th class="sortable"><a href="#void">Status<span class="icon icon-sort icon-inverse"></span></a></th>
-                            <th>IFW</th>
-                            <th class="table-config-column">
-                              <button type="button" class="btn-tblCols" title="Show and hide columns"><i class="icon icon-ellipsis-h icon-inverse"></i></button>
-                            </th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td><a href="master-detail-app.html">12/379,876</a></td>
-                            <td>US1234-767</td>
-                            <td>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </td>
-                            <td>12/13/2014</td>
-                            <td>Issued
-                              <p class="text-muted">01/14/15</p>
-                            </td>
-                            <td colspan="2"><a href="#void">View</a></td>
-                          </tr>
-                          <tr>
-                            <td><a href="master-detail-app.html">12/480,876</a></td>
-                            <td>US1234-767</td>
-                            <td>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </td>
-                            <td>11/13/2014</td>
-                            <td>Issued
-                              <p class="text-muted">12/14/15</p>
-                            </td>
-                            <td colspan="2"><a href="#void">View</a></td>
-                          </tr>
-                          <tr>
-                            <td><a href="master-detail-app.html">12/591,876</a></td>
-                            <td>US1234-767</td>
-                            <td>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </td>
-                            <td>10/13/2014</td>
-                            <td>Issued
-                              <p class="text-muted">11/14/15</p>
-                            </td>
-                            <td colspan="2"><a href="#void">View</a></td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                  <!-- <div class="text-center">
-                                    <div class="pager btn-group">
-                                        <a disabled="" href="#" class="btn btn-default"><i class="icon icon-angle-left"></i></a>
-                                        <a href="#" class="btn btn-default active">1</a>
-                                        <a href="#" class="btn btn-default">2</a>
-                                        <a href="#" class="btn btn-default">3</a>
-                                        <a href="#" class="btn btn-default">4</a>
-                                        <a href="#" class="btn btn-default">5</a>
-                                        <a href="#" class="btn btn-default"><i class="icon icon-angle-right"></i></a>
-                                    </div>
-                                </div> -->
-                </div>
-              </div>
-              <aside class="aside collections padding-2 hide">
-                <a id="supportInfo" tabindex="-1"></a>
-                <div class="panel--collections panel panel-default">
-                  <div class="panel-heading">
-                    <div class="panel__title">
-                      <button class="close" type="button" aria-label="Close"><span>&times;</span></button>
-                      <span class="icon icon-star"></span> <strong>Collections</strong>
-                    </div>
-                  </div>
-                  <div class="panel__actionBar">
-                    <span class="icon icon-download icon-inverse" role="button" data-toggle="tooltip" data-placement="top" aria-label="Download all" title="Download all"></span>
-                    <span class="icon icon-print icon-inverse" role="button" data-toggle="tooltip" data-placement="top" aria-label="Print" title="Print"></span>
-                  </div>
-                  <div class="panel-body">
-                    <table class="table--collections table table-hover table-condensed">
-                      <thead>
-                        <tr>
-                          <th><a href="#collections1" data-toggle="collapsible" aria-label="Expand or Collapse" aria-expanded="false"><i aria-hidden="true" class="icon icon-plus-square-o"></i></a></th>
-                          <th><a class="link-appNumSearch" href="#void">US <span class="appNum">11315345</span></a></th>
-                          <th><a data-placement="top" data-toggle="tooltip" title="" aria-label="Remove from Collections" href="" data-original-title="Remove from Collections"><i aria-hidden="true" class="icon icon-close icon-muted"></i></a></th>
-                        </tr>
-                      </thead>
-                      <tbody id="collections1">
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="#void" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Transmittal of New Application"></i></a></td>
-                          <td><a href="" aria-label="Open Transmittal of New Application">Transmittal of New Application</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Specification"></i></a></td>
-                          <td><a href="" aria-label="Open Specification">Specification</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Nonpublication request from applicant"></i></a></td>
-                          <td><a href="" aria-label="Open Nonpublication request from applicant">Nonpublication request from applicant</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="" target="_blank" class="pull-right" aria-label="Download Application Data Sheet"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Application Data Sheet"></i></a></td>
-                          <td><a href="" target="_blank" aria-label="Open Application Data Sheet">Application Data Sheet</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                      </tbody>
-                    </table>
-                    <table class="table--collections table table-hover table-condensed">
-                      <thead>
-                        <tr>
-                          <th><a href="#collections2" data-toggle="collapsible" aria-label="Expand or Collapse" aria-expanded="false"><i aria-hidden="true" class="icon icon-plus-square-o"></i></a></th>
-                          <th><a class="link-appNumSearch" href="#void">US <span class="appNum">11315342</span></a></th>
-                          <th><a data-placement="top" data-toggle="tooltip" title="" aria-label="Remove from Collections" href="" data-original-title="Remove from Collections"><i aria-hidden="true" class="icon icon-close icon-muted"></i></a></th>
-                        </tr>
-                      </thead>
-                      <tbody id="collections2">
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="#void" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Transmittal of New Application"></i></a></td>
-                          <td><a href="" aria-label="Open Transmittal of New Application">Transmittal of New Application</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Specification"></i></a></td>
-                          <td><a href="" aria-label="Open Specification">Specification</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Nonpublication request from applicant"></i></a></td>
-                          <td><a href="" aria-label="Open Nonpublication request from applicant">Nonpublication request from applicant</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="" target="_blank" class="pull-right" aria-label="Download Application Data Sheet"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Application Data Sheet"></i></a></td>
-                          <td><a href="" target="_blank" aria-label="Open Application Data Sheet">Application Data Sheet</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                      </tbody>
-                    </table>
-                    <table class="table--collections table table-hover table-condensed">
-                      <thead>
-                        <tr>
-                          <th><a href="#collections3" data-toggle="collapsible" aria-label="Expand or Collapse" aria-expanded="false"><i aria-hidden="true" class="icon icon-plus-square-o"></i></a></th>
-                          <th><a class="link-appNumSearch" href="#void">US <span class="appNum">11294613</span></a></th>
-                          <th><a data-placement="top" data-toggle="tooltip" title="" aria-label="Remove from Collections" href="" data-original-title="Remove from Collections"><i aria-hidden="true" class="icon icon-close icon-muted"></i></a></th>
-                        </tr>
-                      </thead>
-                      <tbody id="collections3">
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="#void" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Transmittal of New Application"></i></a></td>
-                          <td><a href="" aria-label="Open Transmittal of New Application">Transmittal of New Application</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Specification"></i></a></td>
-                          <td><a href="" aria-label="Open Specification">Specification</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Nonpublication request from applicant"></i></a></td>
-                          <td><a href="" aria-label="Open Nonpublication request from applicant">Nonpublication request from applicant</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                        <tr class="hide" aria-hidden="true">
-                          <td><a href="" target="_blank" class="pull-right" aria-label="Download Application Data Sheet"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Application Data Sheet"></i></a></td>
-                          <td><a href="" target="_blank" aria-label="Open Application Data Sheet">Application Data Sheet</a></td>
-                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
-                        </tr>
-                      </tbody>
-                    </table>
                   </div>
                 </div>
-              </aside>
-
+                <div class="table--searchResults js-tableSwitch">
+                  <div class="table-responsive">
+                    {{{body}}}
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
-        </div>
-      </div>
-      <div class="pane-right aside keyline-bottom">
-        <!--F <div class="padding-2">
-        <a id="supportInfo" tabindex="-1"></a>
-        <h3 class="margin-top-0">Help</h3>
-        <h4 class="h6 text-uppercase text-muted">Resources</h4>
-        <ul class="list-unstyled">
-            <li><a href="">Search query suggestions</a></li>
-            <li><a href="">Instructional videos</a></li>
-        </ul>
-        <h4 class="h6 text-uppercase text-muted"><abbr title="Frequently Asked Questions">Faq</abbr></h4>
-        <ul class="list-unstyled">
-            <li><a href="">How do I add an application to Collections?</a></li>
-            <li><a href="">What is advanced search?</a></li>
-        </ul>
-    </div> -->
-      </div>
-
-    </div>
-    <div id="modal-appSettings" class="modal fade in" tabindex="-1" role="dialog" aria-labelledby="hd-appSettings">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <button data-dismiss="modal" class="close" type="button"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button>
-            <span class="h4 modal-title" id="hd-appSettings">Application settings</span>
-          </div>
-          <div class="modal-body">
-            <div class="nav-settings tabs-responsive btn-group">
-              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Notifications <span class="caret"></span>
-              </button>
-              <ul class="dropdown-menu">
-                <li class="active"><a href="#" data-toggle="tab" role="tab">Notifications</a></li>
-                <li><a href="#" data-toggle="tab" role="tab">Tracked Systems</a></li>
-                <li><a href="#" data-toggle="tab" role="tab">Reports</a></li>
-                <li class="disabled" data-toggle="tab" role="tab"><a href="#">Favorites</a></li>
-              </ul>
-            </div>
-            <!-- <form class="form-appSettings form-horizontal" role="form" style="margin-left: 20px;"> -->
-            <fieldset>
-              <legend>Select notification types you would like to receive:</legend>
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox" checked value="option1" id="chk1" name="optionsCheckboxes">System alerts</label>
-              </div>
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox" checked value="option1" id="chk2" name="optionsCheckboxes">New system added or removed</label>
-              </div>
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox" value="option1" id="chk3" name="optionsCheckboxes">Report completion</label>
-              </div>
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox" value="option1" id="chk4" name="optionsCheckboxes">Data thresholds</label>
-              </div>
-            </fieldset>
-            <!-- </form> -->
-          </div>
-          <div class="modal-footer">
-            <button class="pull-left btn btn-default" type="button" data-dismiss="modal">Cancel</button>
-            <button class="btn btn-primary" type="button" data-dismiss="modal">Save Changes</button>
-          </div>
-        </div>
-      </div>
-    </div>
-
-
-    <div class="config-ui">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <button class="btn btn-icon-only toggle"><span class="icon icon-inverse"></span></button><span tabindex="0" class="panel__title">UI Configuration</span></div>
-        <div class="panel-body">
-          <ul class="list-unstyled">
-            <li class="switch switch--container">
-              <input type="checkbox" checked id="chk-container" class="js-chkPanels" autocomplete="off">
-              <label data-off="Fixed" data-on="Fluid" for="chk-container">Page container</label>
-            </li>
-            <li class="switch switch--pane">
-              <input type="checkbox" data-target="pane-left" id="chk-leftPane" class="js-chkPanels" autocomplete="off">
-              <label data-off="OFF" data-on="ON" for="chk-leftPane">Left pane</label>
-            </li>
-            <li class="switch switch--pane">
-              <input type="checkbox" data-target="pane-right" id="chk-rightPane" class="js-chkPanels" autocomplete="off">
-              <label data-off="OFF" data-on="ON" for="chk-rightPane">Right pane</label>
-            </li>
-            <li class="switch">
-              <input type="checkbox" data-target="tabs-results" id="chk-tabs" autocomplete="off">
-              <label data-off="OFF" data-on="ON" for="chk-tabs">Tabs</label>
-            </li>
-            <li class="switch">
-              <input type="checkbox" data-target="collections" id="chk-collections" autocomplete="off">
-              <label data-off="OFF" data-on="ON" for="chk-collections">Collections panel</label>
-            </li>
-            <li class="switch">
-              <input type="checkbox" data-target="list-keywords" checked id="chk-keywords" autocomplete="off">
-              <label data-off="OFF" data-on="ON" for="chk-keywords">Filter keywords</label>
-            </li>
-            <li class="divider"><span tabindex="0" class="h5">Filter style</span></li>
-            <li class="switch">
-              <input type="radio" data-target="filters-accordion" checked name="filtersSwitch" id="rdo-accordion" autocomplete="off">
-              <label data-off="OFF" data-on="ON" for="rdo-accordion">Accordion</label>
-            </li>
-            <li class="switch">
-              <input type="radio" data-target="filters-flat" name="filtersSwitch" id="rdo-flat" autocomplete="off">
-              <label data-off="OFF" data-on="ON" for="rdo-flat">Flat</label>
-            </li>
-            <li class="divider"><span tabindex="0" class="h5">Search results</span></li>
-            <li class="switch">
-              <input type="radio" data-target="table--searchResults" checked name="tblsSwitch" class="chk-switchTbl" id="rdo-expRows" autocomplete="off">
-              <label data-off="OFF" data-on="ON" for="rdo-expRows">Expanding rows</label>
-            </li>
-            <!-- <li class="switch">
-                        <input type="radio" data-target="table--multiline" name="tblsSwitch" class="chk-switchTbl" id="rdo-multiline" autocomplete="off">
-                        <label data-off="OFF" data-on="ON" for="rdo-multiline">Multi-line</label>
-                    </li> -->
-            <li class="switch">
-              <input type="radio" data-target="table--border" name="tblsSwitch" class="chk-switchTbl" id="rdo-bordered" autocomplete="off">
-              <label data-off="OFF" data-on="ON" for="rdo-bordered">Bordered</label>
-            </li>
-          </ul>
         </div>
       </div>
     </div>
   </main>
-
   <script src="/bower_components/designpatterns/generated/scripts/vendor.js"></script>
   <script src="/bower_components/designpatterns/generated/scripts/plugins.js"></script>
   <script src="https://components.uspto.gov/js/ais/2-4-pattern-library.js"></script>
   <script src="/bower_components/designpatterns/generated/scripts/appDemo.js"></script>
   <script src="/client/scripts/script.js"></script>
-
-  <script type="text/javascript">
-    function resizeText(multiplier) {
-      if (document.getElementById('results').style.fontSize == "") {
-        document.getElementById('results').style.fontSize = "1.0em";
-      }
-      document.getElementById('results').style.fontSize = parseFloat(document.getElementById('results').style.fontSize) + (multiplier * 0.2) + "em";
-    }
-  </script>
-
 </body>
-
 </html>

--- a/searchtool/server/views/layout_original.hbs
+++ b/searchtool/server/views/layout_original.hbs
@@ -1,0 +1,783 @@
+<!DOCTYPE html>
+<html class="no-js">
+
+<head>
+  <meta charset="utf-8">
+
+  <title>Office Action Search</title>
+
+  <meta name="description" content="Office Action Search">
+  <meta name="keywords" content="office actions">
+
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+  <meta name="theme-color" content="#004c97">
+
+  <meta property="og:title" content="Customize search results">
+  <meta property="og:description" content="">
+
+  <link rel="shortcut icon" href="/bower_components/designpatterns/generated/favicon.ico">
+
+  <!--[if lte IE 9]>
+            <script src="/bower_components/designpatterns/generated/vendor/matchMedia/matchMedia.js"></script>
+            <script src="/bower_components/designpatterns/generated/vendor/html5shiv/html5shiv.min.js"></script>
+        <![endif]-->
+
+  <link href="/bower_components/designpatterns/generated/styles/vendor.css" rel="stylesheet" />
+  <link href="/bower_components/designpatterns/generated/styles/main.css" rel="stylesheet" />
+  <link href="/bower_components/designpatterns/generated/styles/appDemo.min.css" rel="stylesheet" />
+  <link rel="stylesheet" type="text/css" href="/client/styles/layout_custom.css">
+  <style>
+    /* fix for IE transparent scroll bar */
+
+    @-ms-viewport {
+      width: auto !important;
+    }
+  </style>
+</head>
+
+<body class="search-results">
+  <!--[if lt IE 9]>
+        <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+    <![endif]-->
+
+
+  <div class="skipLinks alert-info">
+    <a class="sr-only focusable" href="#search">Skip to search</a>
+    <a class="sr-only focusable" href="#searchResults">Skip to search results</a>
+    <a class="sr-only focusable" href="#filters">Skip to search results filters</a>
+  </div>
+  <header class="app-header clearfix">
+    <nav class="navbar navbar-inverse">
+      <div class="container-fluid container--full">
+        <div class="navbar-header">
+          <button aria-controls="navbar" aria-expanded="false" data-target="#navbar" data-toggle="collapse" class="navbar-toggle collapsed" type="button">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <!-- <h1 class="margin-top-0"><a class="navbar-brand" href="dashboard.html">
+                    <span class="uspto-header__top__logo uspto-logo-svg margin-right-2"></span> Application Monitor <small>DEMO</small></a></h1> -->
+        </div>
+        <div class="navbar-collapse collapse" id="navbar">
+          <ul class="nav navbar-nav navbar-right">
+            <li><a href="#" data-toggle="tooltip" data-placement="left" title="Application alerts"><i class="icon icon-warning icon-inverse"></i><span class="ex-header--icon-badge">2</span></a></li>
+            <li class="dropdown">
+              <a aria-expanded="false" aria-haspopup="true" role="button" data-toggle="dropdown" class="dropdown-toggle" href="#"><i class="icon icon-user margin-right-1 icon-inverse"></i>{{#if email}} {{email}} {{/if}}<span class="caret"></span></a>
+              <ul class="dropdown-menu">
+                <!-- <li><a href="user-profile.html">User Profile</a></li>
+                           <li><a href="#modal-appSettings" data-toggle="modal">Settings</a></li> -->
+                <li class="divider" role="separator"></li>
+                <li><a href="/logout">Sign out</a></li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+  </header>
+
+
+  <main class="wrapper container-fluid container--full">
+    <div class="row-grid">
+      <nav class="pane-left keyline-bottom">
+        <a tabindex="-1" id="contentNav"></a>
+        <div class="close-sidebar keyline-bottom clearfix">
+          <button type="button" class="btn-closeSidebar pull-right btn btn-sm btn-default btn-hover"><i class="icon icon-angle-double-left"></i> Close</button>
+        </div>
+        <ul role="tab-list" class="nav nav-stacked">
+          <li tabindex="0" class="category" role="presentation"><i class="icon icon-dashboard"></i> Dashboards</li>
+          <li role="presentation"><a href="#" role="tab">Systems summary</a></li>
+          <li role="presentation"><a href="#" role="tab">System A</a></li>
+          <li role="presentation"><a href="#" role="tab">System B</a></li>
+          <li role="presentation"><a href="#" role="tab">System C</a></li>
+          <li tabindex="0" class="category" role="presentation"><i class="icon icon-bar-chart"></i> Reports</li>
+          <li role="presentation"><a href="#" role="tab">Fees and transactions</a></li>
+          <li role="presentation"><a href="#" role="tab">Trends</a></li>
+          <li role="presentation"><a href="#" role="tab">Disposition</a></li>
+          <li role="presentation"><a href="#" role="tab">Custom</a></li>
+        </ul>
+      </nav>
+
+      <div class="pane-center col">
+        <div class="panel--page panel panel-default">
+          <a tabindex="-1" id="search"></a>
+          <div class="header keyline-bottom">
+            <form role="form" action="/newsearch" class="padding-top-2 padding-right-2 padding-bottom-2">
+              <h2 class="margin-top-0">Patent Data Search</h2>
+              {{#if accessOK}}
+              <div class="input-search input-group">
+                <input type="text" name="q" value="{{#if term}}{{term}}{{/if}}" aria-label="Search all fields" title="Search all fields" class="form-control" placeholder="Search all fields" id="txt-find">
+                <span class="input-group-btn">
+                  <button class="btn btn-primary"><i class="icon icon-inverse icon-search"></i></button>
+                </span>
+              </div>
+              <label class="radio-inline">
+                <input type="radio" name="dataset" id="inlineRadio1" value="oa" {{#unless ptab}}checked{{/unless}}> Office Actions
+              </label>
+              <label class="radio-inline">
+                <input type="radio" name="dataset" id="inlineRadio2" value="ptab" {{#if ptab}}checked{{/if}}> PTAB
+              </label>
+              <div style="margin-bottom: 0;" class="help-block">
+                <b><i>Examples: Search for law 112(f) ..... <code>"112\(f\)"</code>  or search for Art Unit .. <code>"Art Unit 3669"~2</code>  </i></b>
+                <!-- <a href="#void">Show advanced search</a> -->
+              </div>
+
+              <div class="help-button">
+                <a href="/help" class="btn btn-primary">Help</a>
+              </div>
+
+              {{/if}}
+
+
+              <div class="tabs-results tabs-responsive btn-group hide">
+                <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default dropdown-toggle hide" type="button">
+                  All<span class="badge">100</span> <span class="caret"></span>
+                </button>
+                <ul class="nav nav-tabs">
+                  <li class="active"><a data-toggle="tab" role="tab" href="#"><span>All</span><span class="badge">100</span></a></li>
+                  <li><a role="tab" data-toggle="tab" href="#"><span>Unassigned</span><span class="badge">45</span></a></li>
+                  <li><a role="tab" data-toggle="tab" href="#"><span>Partially assigned</span><span class="badge">34</span></a></li>
+                  <li><a role="tab" data-toggle="tab" href="#"><span>Fully assigned</span><span class="badge">3</span></a></li>
+                </ul>
+              </div>
+          </div>
+          <div class="main-wrapper row-grid">
+            <div class="app-sidebar filters keyline-right">
+              {{#unless accessOK}}
+              This Search engine is for Authorized users only.
+              <hr> For access, please contact Thomas Beach
+              {{/unless}}
+              <a tabindex="-1" id="filters"></a>
+              <div class="close-sidebar keyline-bottom clearfix">
+                <button class="btn-closeSidebar pull-right btn btn-sm btn-default btn-hover"><i class="icon icon-angle-double-left"></i> Close</button>
+              </div>
+              {{#if accessOK}}
+                  <div class="filter-heading">
+                    <span tabindex="0" class="h4">Refine by</span> <a class="filters-clear" href="">Clear</a>
+                  </div>
+              {{/if}}
+
+              <!--  <form class="filters-accordion js-filterSwitch" role="form"> -->
+              <!-- <div class="h5" tabindex="0">Assignment</div> -->
+              <div class="filter-list">
+                <!--    <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#2filterGroup8">Filing year <i class="icon icon-angle-right pull-right"></i></a>
+        <div id="2filterGroup8" class="collapse">
+            <div class="filter-group-content">
+                <div class="form-group">
+                    <ul class="list-unstyled">
+                        <li><a href="">2014</a></li>
+                        <li><a href="">2013</a></li>
+                        <li><a href="">2012</a></li>
+                        <li><a href="">2011</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div> -->
+                {{#if accessOK}}
+                    <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#2filterGroup1"><i class="icon icon-angle-right pull-right"></i> Filing date range</a>
+                {{/if}}
+                <div id="2filterGroup1" class="collapse">
+                  <div class="filter-group-content">
+                    <div class="row">
+                      <div class="form-group col-sm-6">
+                        <span class="input-icon icon icon-calendar-o"></span>
+                        <input name="fromdate" type="text" placeholder="Start" class="datepicker form-control" value="{{fromdate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="Start date" aria-label="Start date">
+                      </div>
+                      <div class="form-group col-sm-6">
+                        <span class="input-icon icon icon-calendar-o"></span>
+                        <input name="todate" type="text" placeholder="End" class="datepicker form-control" value="{{todate}}" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="End date" aria-label="End date">
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                {{#if accessOK}}
+                
+              
+
+                <div>
+                  <input type="text" name="art_unit"  aria-label="Search Art Unit Number" title="Search Art Unit Number" class="form-control" placeholder="Search Art Unit Number" value="{{#if artUnit}} {{artUnit}}{{/if}}">
+                  <span>Please use 4-6 digit number</span>
+                </div>
+
+                <div class="input-search input-group" style="margin-left: 1em;">
+                  <span class="input-group-btn">
+                    <button class="btn btn-primary" style="z-index: 1;">Refine Search</button>
+                  </span>
+                </div>
+                {{/if}}
+                </form>
+                <!--  <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#2filterGroup2"><i class="icon icon-angle-right pull-right"></i> <span class="badge pull-right">1</span> Application type</a>
+        <div id="2filterGroup2" class="collapse">
+            <div class="filter-group-content">
+                <div class="form-group">
+                    <div class="checkbox">
+                        <label>
+                            <input checked type="checkbox">Assignment <span class="text-muted">(13)</span></label>
+                    </div>
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox"> Change of name <span class="text-muted">(45)</span></label>
+                    </div>
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox"> Trademark <span class="text-muted">(18)</span></label>
+                    </div>
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox"> Certification <span class="text-muted">(32)</span></label>
+                    </div>
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox"> Service <span class="text-muted">(43)</span></label>
+                    </div>
+                    <a href="#void">Show 12 more...</a>
+                </div>
+            </div>
+        </div>
+            <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#2filterGroup5"><i class="icon icon-angle-right pull-right"></i> Applicant</a>
+        <div id="2filterGroup5" class="collapse">
+            <div class="filter-group-content">
+                <div class="form-group">
+                    <div class="form-group">
+                        <ul class="list-unstyled">
+                            <li><a href="">JOHN SMITH ET AL</a></li>
+                            <li><a href="">JANE LLC</a></li>
+                            <li><a href="">JOHNSON CO</a></li>
+                            <li><a href="">INITECH</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="h5" tabindex="0">Assignee (Owner)</div>
+    <div class="filter-list">
+            <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#3filterGroup8">Assignee <i class="icon icon-angle-right pull-right"></i></a>
+        <div id="3filterGroup8" class="collapse">
+            <div class="filter-group-content">
+                <div class="form-group">
+                    <ul class="list-unstyled">
+                        <li><a href="">John Smith Et al.</a></li>
+                        <li><a href="">Jane LLC</a></li>
+                        <li><a href="">Johnson Co.</a></li>
+                        <li><a href="">Initech</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+            <a class="filter-group-title" href="#void" data-toggle="collapse" data-target="#3filterGroup2"><i class="icon icon-angle-right pull-right"></i> Assignee country</a>
+        <div id="3filterGroup2" class="collapse">
+            <div class="filter-group-content">
+                <div class="form-group">
+                    <ul class="list-unstyled">
+                        <li><a href="">United States</a></li>
+                        <li><a href="">France</a></li>
+                        <li><a href="">Germany</a></li>
+                        <li><a href="">Hungary</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+          <div class="padding-2">
+        <a id="supportInfo" tabindex="-1"></a>
+        <h3 class="margin-top-0">Help</h3>
+        <h4 class="h6 text-uppercase text-muted">Resources</h4>
+        <ul class="list-unstyled">
+            <li><a href="/help">Search query suggestions</a></li>
+        </ul>
+        <h4 class="h6 text-uppercase text-muted"><abbr title="Frequently Asked Questions">Faq</abbr></h4>
+        <ul class="list-unstyled">
+            <li><a href="">How many office actions are loaded?</a></li>
+            <li><a href="">When are updates applied?</a></li>
+        </ul>
+    </div>-
+    </div>
+<!-- </form> -->
+
+                <!-- <form class="filters-flat js-filterSwitch hide" role="form"> -->
+                <!--  <div class="filter">
+        <label for="s2id_autogen2" class="h5 control-label">Select year</label>
+        <select class="select2 form-control">
+            <option>2015</option>
+            <option>2014</option>
+            <option>2013</option>
+            <option>2012</option>
+        </select>
+    </div>
+    <div class="filter">
+        <div class="h5" tabindex="0">Filing date range</div>
+        <div class="form-group">
+            <span class="input-icon icon icon-calendar-o"></span>
+            <input type="text" placeholder="Start" class="datepicker form-control" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="Start date" aria-label="Start date">
+        </div>
+        <div class="form-group margin-bottom-0">
+            <span class="input-icon icon icon-calendar-o"></span>
+            <input type="text" placeholder="End" class="datepicker form-control" data-inputmask="'mask': 'm/d/y', 'placeholder': 'mm/dd/yyyy'" title="End date" aria-label="End date">
+        </div>
+    </div>
+    <div class="filter">
+        <div class="h5" tabindex="0">Applicant</div>
+        <label for="s2id_autogen4" class="control-label">Select applicant</label>
+        <select class="select2 form-control">
+            <option>All</option>
+            <option>JOHN SMITH ET AL</option>
+            <option>JANE LLC</option>
+            <option>JOHNSON CO</option>
+            <option>INITECH</option>
+        </select>
+    </div>
+    <div class="filter">
+        <div class="h5" tabindex="0">Application type</div>
+        <div class="form-group margin-bottom-0">
+            <div class="checkbox">
+                <label>
+                    <input checked type="checkbox">Assignment <span class="text-muted">(13)</span>
+                </label>
+            </div>
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox"> Change of name <span class="text-muted">(45)</span>
+                </label>
+            </div>
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox"> Trademark <span class="text-muted">(18)</span>
+                </label>
+            </div>
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox"> Certification <span class="text-muted">(32)</span>
+                </label>
+            </div>
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox"> Service <span class="text-muted">(43)</span>
+                </label>
+            </div>
+            <a href="#void">Show 12 more...</a>
+        </div>
+    </div>
+    <div class="filter">
+        <fieldset>
+            <legend class="h5 control-label">Assignee country</legend>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="countryOpts" id="rdo-usa" value="" checked>United States<span class="help-block">(including all US territories)</span>
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="countryOpts" id="rdo-france" value="">France</label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="countryOpts" id="rdo-germany" value="">Germany</label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="countryOpts" id="rdo-gungary" value="">Hungary</label>
+            </div>
+        </fieldset>-->
+              </div>
+
+            </div>
+            <div class="row-grid">
+              <div class="main-content col">
+                <div class="panel-body">
+                  <div class="results-header">
+                    <a tabindex="-1" id="searchResults"></a>
+                    <a href="#void" class="link-sidebar"><i class="icon icon-columns"></i>Refine</a>
+                    <div class="pg-actions clearfix">
+                        <div class="row">
+                            {{#if term}}<span> Search Term: <span class="label label-success subtle">{{term}}</span> </span>{{/if}}
+
+                            {{#if artUnit}}<span> Art Unit: <span class="label label-success subtle">{{artUnit}}</span></span>{{/if}}
+
+                            {{#if total}}<br>
+                            <span class="pull-left margin-top-0">{{total}} results took {{took}} ms</span>
+                            <span><a href="javascript:void(0);" onclick="resizeText(1)" id="plustext"> [+] Make results bigger</a> | <a href="javascript:void(0);" onclick="resizeText(-1)" id="minustext">[-] Make results smaller</a></span>
+                            {{/if}}
+
+                          <div class="btn-pgActions btn-group">
+                            {{#if term}}
+                              <button aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" class="btn btn-default dropdown-toggle" id="btn-pgActions">Download <span class="caret"></span></button>
+                              <ul aria-labelledby="btn-pgActions" class="dropdown-menu">
+                                <!-- <li role="presentation"><a href="#">Print</a></li>
+                                                    <li class="divider" role="separator"></li> -->
+                                <!-- <li role="presentation"><a href="#">Download Excel</a></li> -->
+                                <li role="presentation"><a target="_BLANK" href="/download?q={{term}}">Download CSV</a></li>
+                              </ul>
+                              {{/if}}
+                          </div>
+                        </div>
+                    </div>
+                    <!-- <ul class="list-keywords list-unstyled margin-bottom-0">
+                                        <li tabindex="0" class="filter-value"><span>Application type: Service</span> <i class="icon icon-close icon-muted"></i></li>
+                                        <li tabindex="0" class="filter-value"><span>Applicant: JANE LLC</span> <i class="icon icon-close icon-muted"></i></li>
+                                    </ul> -->
+                  </div>
+                  <div class="table--searchResults js-tableSwitch">
+                  {{#if term}}
+                      <div class="table--actions row">
+                        <div class="col-xs-6">
+
+                        </div>
+                        <div class="col-xs-6">
+                          <!-- <div class="btn-group dropdown pull-right">
+                <button id="btn-displayOpts" type="button" class="btn-displayOpts btn btn-default dropdown-toggle" data-toggle="dropdown">10 per page <span class="caret"></span></button>
+                <ul class="dropdown-menu" role="menu" aria-labelledby="btn-displayOpts">
+                    <li role="presentation" class="dropdown-header">Show up to</li>
+                    <li role="presentation" class="active"><a role="menuitem" tabindex="-1" href="#">10 items</a></li>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" href="#">25 items</a></li>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" href="#">50 items</a></li>
+                    <li role="presentation"><a role="menuitem" tabindex="-1" href="#">100 items</a></li>
+                </ul>
+            </div> -->
+                        </div>
+                      </div>
+                      {{/if}}
+                        <div class="table-responsive">
+                          {{{body}}}
+                        </div>
+                  </div>
+                  <div class="table--border js-tableSwitch hide">
+                    <div class="table--actions row">
+                      <div class="col-xs-12">
+                        <div class="btn-group dropdown">
+                          <button id="btn-displayOpts" type="button" class="btn-displayOpts btn btn-default dropdown-toggle" data-toggle="dropdown">10 per page <span class="caret"></span></button>
+                          <ul class="dropdown-menu" role="menu" aria-labelledby="btn-displayOpts">
+                            <li role="presentation" class="dropdown-header">Show up to</li>
+                            <li role="presentation" class="active"><a role="menuitem" tabindex="-1" href="#">10 items</a></li>
+                            <li role="presentation"><a role="menuitem" tabindex="-1" href="#">25 items</a></li>
+                            <li role="presentation"><a role="menuitem" tabindex="-1" href="#">50 items</a></li>
+                            <li role="presentation"><a role="menuitem" tabindex="-1" href="#">100 items</a></li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="table-responsive">
+                      <table class="table-bordered table table-sortable table-hover table-inverse">
+                        <thead>
+                          <tr>
+                            <th class="sortable"><a href="#void">Application
+                                    <abbr title="Number">#</abbr><span class="icon icon-sort icon-inverse"></span></a></th>
+                            <th class="sortable"><a href="#void">Docket
+                                    <abbr title="Number">#</abbr><span class="icon icon-sort icon-inverse"></span></a></th>
+                            <th>Title</th>
+                            <th class="sortable"><a href="#void">Filing Date<span class="icon icon-caret-down icon-inverse"></span></a></th>
+                            <th class="sortable"><a href="#void">Status<span class="icon icon-sort icon-inverse"></span></a></th>
+                            <th>IFW</th>
+                            <th class="table-config-column">
+                              <button type="button" class="btn-tblCols" title="Show and hide columns"><i class="icon icon-ellipsis-h icon-inverse"></i></button>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr>
+                            <td><a href="master-detail-app.html">12/379,876</a></td>
+                            <td>US1234-767</td>
+                            <td>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </td>
+                            <td>12/13/2014</td>
+                            <td>Issued
+                              <p class="text-muted">01/14/15</p>
+                            </td>
+                            <td colspan="2"><a href="#void">View</a></td>
+                          </tr>
+                          <tr>
+                            <td><a href="master-detail-app.html">12/480,876</a></td>
+                            <td>US1234-767</td>
+                            <td>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </td>
+                            <td>11/13/2014</td>
+                            <td>Issued
+                              <p class="text-muted">12/14/15</p>
+                            </td>
+                            <td colspan="2"><a href="#void">View</a></td>
+                          </tr>
+                          <tr>
+                            <td><a href="master-detail-app.html">12/591,876</a></td>
+                            <td>US1234-767</td>
+                            <td>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </td>
+                            <td>10/13/2014</td>
+                            <td>Issued
+                              <p class="text-muted">11/14/15</p>
+                            </td>
+                            <td colspan="2"><a href="#void">View</a></td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                  <!-- <div class="text-center">
+                                    <div class="pager btn-group">
+                                        <a disabled="" href="#" class="btn btn-default"><i class="icon icon-angle-left"></i></a>
+                                        <a href="#" class="btn btn-default active">1</a>
+                                        <a href="#" class="btn btn-default">2</a>
+                                        <a href="#" class="btn btn-default">3</a>
+                                        <a href="#" class="btn btn-default">4</a>
+                                        <a href="#" class="btn btn-default">5</a>
+                                        <a href="#" class="btn btn-default"><i class="icon icon-angle-right"></i></a>
+                                    </div>
+                                </div> -->
+                </div>
+              </div>
+              <aside class="aside collections padding-2 hide">
+                <a id="supportInfo" tabindex="-1"></a>
+                <div class="panel--collections panel panel-default">
+                  <div class="panel-heading">
+                    <div class="panel__title">
+                      <button class="close" type="button" aria-label="Close"><span>&times;</span></button>
+                      <span class="icon icon-star"></span> <strong>Collections</strong>
+                    </div>
+                  </div>
+                  <div class="panel__actionBar">
+                    <span class="icon icon-download icon-inverse" role="button" data-toggle="tooltip" data-placement="top" aria-label="Download all" title="Download all"></span>
+                    <span class="icon icon-print icon-inverse" role="button" data-toggle="tooltip" data-placement="top" aria-label="Print" title="Print"></span>
+                  </div>
+                  <div class="panel-body">
+                    <table class="table--collections table table-hover table-condensed">
+                      <thead>
+                        <tr>
+                          <th><a href="#collections1" data-toggle="collapsible" aria-label="Expand or Collapse" aria-expanded="false"><i aria-hidden="true" class="icon icon-plus-square-o"></i></a></th>
+                          <th><a class="link-appNumSearch" href="#void">US <span class="appNum">11315345</span></a></th>
+                          <th><a data-placement="top" data-toggle="tooltip" title="" aria-label="Remove from Collections" href="" data-original-title="Remove from Collections"><i aria-hidden="true" class="icon icon-close icon-muted"></i></a></th>
+                        </tr>
+                      </thead>
+                      <tbody id="collections1">
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="#void" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Transmittal of New Application"></i></a></td>
+                          <td><a href="" aria-label="Open Transmittal of New Application">Transmittal of New Application</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Specification"></i></a></td>
+                          <td><a href="" aria-label="Open Specification">Specification</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Nonpublication request from applicant"></i></a></td>
+                          <td><a href="" aria-label="Open Nonpublication request from applicant">Nonpublication request from applicant</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="" target="_blank" class="pull-right" aria-label="Download Application Data Sheet"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Application Data Sheet"></i></a></td>
+                          <td><a href="" target="_blank" aria-label="Open Application Data Sheet">Application Data Sheet</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <table class="table--collections table table-hover table-condensed">
+                      <thead>
+                        <tr>
+                          <th><a href="#collections2" data-toggle="collapsible" aria-label="Expand or Collapse" aria-expanded="false"><i aria-hidden="true" class="icon icon-plus-square-o"></i></a></th>
+                          <th><a class="link-appNumSearch" href="#void">US <span class="appNum">11315342</span></a></th>
+                          <th><a data-placement="top" data-toggle="tooltip" title="" aria-label="Remove from Collections" href="" data-original-title="Remove from Collections"><i aria-hidden="true" class="icon icon-close icon-muted"></i></a></th>
+                        </tr>
+                      </thead>
+                      <tbody id="collections2">
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="#void" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Transmittal of New Application"></i></a></td>
+                          <td><a href="" aria-label="Open Transmittal of New Application">Transmittal of New Application</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Specification"></i></a></td>
+                          <td><a href="" aria-label="Open Specification">Specification</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Nonpublication request from applicant"></i></a></td>
+                          <td><a href="" aria-label="Open Nonpublication request from applicant">Nonpublication request from applicant</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="" target="_blank" class="pull-right" aria-label="Download Application Data Sheet"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Application Data Sheet"></i></a></td>
+                          <td><a href="" target="_blank" aria-label="Open Application Data Sheet">Application Data Sheet</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <table class="table--collections table table-hover table-condensed">
+                      <thead>
+                        <tr>
+                          <th><a href="#collections3" data-toggle="collapsible" aria-label="Expand or Collapse" aria-expanded="false"><i aria-hidden="true" class="icon icon-plus-square-o"></i></a></th>
+                          <th><a class="link-appNumSearch" href="#void">US <span class="appNum">11294613</span></a></th>
+                          <th><a data-placement="top" data-toggle="tooltip" title="" aria-label="Remove from Collections" href="" data-original-title="Remove from Collections"><i aria-hidden="true" class="icon icon-close icon-muted"></i></a></th>
+                        </tr>
+                      </thead>
+                      <tbody id="collections3">
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="#void" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Transmittal of New Application"></i></a></td>
+                          <td><a href="" aria-label="Open Transmittal of New Application">Transmittal of New Application</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Specification"></i></a></td>
+                          <td><a href="" aria-label="Open Specification">Specification</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="" class="pull-right" aria-label="Download"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Nonpublication request from applicant"></i></a></td>
+                          <td><a href="" aria-label="Open Nonpublication request from applicant">Nonpublication request from applicant</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                        <tr class="hide" aria-hidden="true">
+                          <td><a href="" target="_blank" class="pull-right" aria-label="Download Application Data Sheet"><i class="icon icon-download" data-toggle="tooltip" data-placement="left" data-original-title="Download Application Data Sheet"></i></a></td>
+                          <td><a href="" target="_blank" aria-label="Open Application Data Sheet">Application Data Sheet</a></td>
+                          <td><a data-original-title="Remove from Collections" href="" aria-label="Remove from Collections" title="" data-toggle="tooltip" data-placement="top"><i class="icon icon-close icon-muted" aria-hidden="true"></i></a></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </aside>
+
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="pane-right aside keyline-bottom">
+        <!--F <div class="padding-2">
+        <a id="supportInfo" tabindex="-1"></a>
+        <h3 class="margin-top-0">Help</h3>
+        <h4 class="h6 text-uppercase text-muted">Resources</h4>
+        <ul class="list-unstyled">
+            <li><a href="">Search query suggestions</a></li>
+            <li><a href="">Instructional videos</a></li>
+        </ul>
+        <h4 class="h6 text-uppercase text-muted"><abbr title="Frequently Asked Questions">Faq</abbr></h4>
+        <ul class="list-unstyled">
+            <li><a href="">How do I add an application to Collections?</a></li>
+            <li><a href="">What is advanced search?</a></li>
+        </ul>
+    </div> -->
+      </div>
+
+    </div>
+    <div id="modal-appSettings" class="modal fade in" tabindex="-1" role="dialog" aria-labelledby="hd-appSettings">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button data-dismiss="modal" class="close" type="button"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button>
+            <span class="h4 modal-title" id="hd-appSettings">Application settings</span>
+          </div>
+          <div class="modal-body">
+            <div class="nav-settings tabs-responsive btn-group">
+              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Notifications <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">
+                <li class="active"><a href="#" data-toggle="tab" role="tab">Notifications</a></li>
+                <li><a href="#" data-toggle="tab" role="tab">Tracked Systems</a></li>
+                <li><a href="#" data-toggle="tab" role="tab">Reports</a></li>
+                <li class="disabled" data-toggle="tab" role="tab"><a href="#">Favorites</a></li>
+              </ul>
+            </div>
+            <!-- <form class="form-appSettings form-horizontal" role="form" style="margin-left: 20px;"> -->
+            <fieldset>
+              <legend>Select notification types you would like to receive:</legend>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" checked value="option1" id="chk1" name="optionsCheckboxes">System alerts</label>
+              </div>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" checked value="option1" id="chk2" name="optionsCheckboxes">New system added or removed</label>
+              </div>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" value="option1" id="chk3" name="optionsCheckboxes">Report completion</label>
+              </div>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" value="option1" id="chk4" name="optionsCheckboxes">Data thresholds</label>
+              </div>
+            </fieldset>
+            <!-- </form> -->
+          </div>
+          <div class="modal-footer">
+            <button class="pull-left btn btn-default" type="button" data-dismiss="modal">Cancel</button>
+            <button class="btn btn-primary" type="button" data-dismiss="modal">Save Changes</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+
+    <div class="config-ui">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <button class="btn btn-icon-only toggle"><span class="icon icon-inverse"></span></button><span tabindex="0" class="panel__title">UI Configuration</span></div>
+        <div class="panel-body">
+          <ul class="list-unstyled">
+            <li class="switch switch--container">
+              <input type="checkbox" checked id="chk-container" class="js-chkPanels" autocomplete="off">
+              <label data-off="Fixed" data-on="Fluid" for="chk-container">Page container</label>
+            </li>
+            <li class="switch switch--pane">
+              <input type="checkbox" data-target="pane-left" id="chk-leftPane" class="js-chkPanels" autocomplete="off">
+              <label data-off="OFF" data-on="ON" for="chk-leftPane">Left pane</label>
+            </li>
+            <li class="switch switch--pane">
+              <input type="checkbox" data-target="pane-right" id="chk-rightPane" class="js-chkPanels" autocomplete="off">
+              <label data-off="OFF" data-on="ON" for="chk-rightPane">Right pane</label>
+            </li>
+            <li class="switch">
+              <input type="checkbox" data-target="tabs-results" id="chk-tabs" autocomplete="off">
+              <label data-off="OFF" data-on="ON" for="chk-tabs">Tabs</label>
+            </li>
+            <li class="switch">
+              <input type="checkbox" data-target="collections" id="chk-collections" autocomplete="off">
+              <label data-off="OFF" data-on="ON" for="chk-collections">Collections panel</label>
+            </li>
+            <li class="switch">
+              <input type="checkbox" data-target="list-keywords" checked id="chk-keywords" autocomplete="off">
+              <label data-off="OFF" data-on="ON" for="chk-keywords">Filter keywords</label>
+            </li>
+            <li class="divider"><span tabindex="0" class="h5">Filter style</span></li>
+            <li class="switch">
+              <input type="radio" data-target="filters-accordion" checked name="filtersSwitch" id="rdo-accordion" autocomplete="off">
+              <label data-off="OFF" data-on="ON" for="rdo-accordion">Accordion</label>
+            </li>
+            <li class="switch">
+              <input type="radio" data-target="filters-flat" name="filtersSwitch" id="rdo-flat" autocomplete="off">
+              <label data-off="OFF" data-on="ON" for="rdo-flat">Flat</label>
+            </li>
+            <li class="divider"><span tabindex="0" class="h5">Search results</span></li>
+            <li class="switch">
+              <input type="radio" data-target="table--searchResults" checked name="tblsSwitch" class="chk-switchTbl" id="rdo-expRows" autocomplete="off">
+              <label data-off="OFF" data-on="ON" for="rdo-expRows">Expanding rows</label>
+            </li>
+            <!-- <li class="switch">
+                        <input type="radio" data-target="table--multiline" name="tblsSwitch" class="chk-switchTbl" id="rdo-multiline" autocomplete="off">
+                        <label data-off="OFF" data-on="ON" for="rdo-multiline">Multi-line</label>
+                    </li> -->
+            <li class="switch">
+              <input type="radio" data-target="table--border" name="tblsSwitch" class="chk-switchTbl" id="rdo-bordered" autocomplete="off">
+              <label data-off="OFF" data-on="ON" for="rdo-bordered">Bordered</label>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <script src="/bower_components/designpatterns/generated/scripts/vendor.js"></script>
+  <script src="/bower_components/designpatterns/generated/scripts/plugins.js"></script>
+  <script src="https://components.uspto.gov/js/ais/2-4-pattern-library.js"></script>
+  <script src="/bower_components/designpatterns/generated/scripts/appDemo.js"></script>
+  <script src="/client/scripts/script.js"></script>
+
+  <script type="text/javascript">
+    function resizeText(multiplier) {
+      if (document.getElementById('results').style.fontSize == "") {
+        document.getElementById('results').style.fontSize = "1.0em";
+      }
+      document.getElementById('results').style.fontSize = parseFloat(document.getElementById('results').style.fontSize) + (multiplier * 0.2) + "em";
+    }
+  </script>
+
+</body>
+
+</html>

--- a/searchtool/server/views/newview.hbs
+++ b/searchtool/server/views/newview.hbs
@@ -17,14 +17,14 @@
 
           {{#each result}}
             <div class="media">
-              <h4><a style="cursor:pointer"; onClick="javascript:document.getElementById('action_text').innerHTML =''; document.getElementById('action_text').innerHTML ='<h5>Application ID: {{appid}}, File Doc ID: {{DOCUMENT_IMAGE_ID}}</h5><hr>Pre-Grant Publication Number: <b>{{PRE_GRANT_PUBLICATION_NO}}</b> <br> FK DT Document Type Name: <b>{{FK_DT_DOCUMENT_TYPE_NM}}</b> <br> Inventor String Tx: <b>{{INVENTOR_STRING_TX}}</b> <br> Status Code: <b>{{STATUS_CD}}</b> <br> Inventor Name: <b>{{INVENTOR_GIVEN_NM}} {{INVENTOR_MIDDLE_NM}} {{INVENTOR_FAMILY_NM}}</b> <br> Patent Issue Date: <b>{{PATENT_ISSUE_DT}}</b> <br> Decision Mailed Date: <b>{{DECISION_MAILED_DT}}</b> <br> Pre-Grant Publication Number: <b>{{PRE_GRANT_PUBLICATION_NO}}</b> <br> Applicant Pub Authorization Date: <b>{{APPLICANT_PUB_AUTHORIZATION_DT}}</b> <br> FK DT Business Short Name: <b>{{FK_DT_BUSINESS_SHORT_NM}}</b> <br> Application Type Code: <b>{{APPLICATION_TYPE_CD}}</b> <br> Appeal Number: <b>{{APPEAL_NO}}</b> <br> Inventor QT: <b>{{INVENTOR_QT}}</b> <br> Last Modified TS: <b>{{LAST_MODIFIED_TS}}</b> <br><hr><b>Full Text</b><hr>{{breaklines textdata.[0]}}' ;"  data-item="{{DOCUMENT_IMAGE_ID}}" data-toggle="modal" data-target="#cancelModal"> PTAB DOC ID: {{DOCUMENT_IMAGE_ID}}</a></h4>
+              <h4><a style="cursor:pointer"; onClick="javascript:document.getElementById('action_text').innerHTML =''; document.getElementById('action_text').innerHTML ='<h5>Application ID: {{appid}}, File Doc ID: {{DOCUMENT_IMAGE_ID}}</h5><hr>Pre-Grant Publication Number: <b>{{PRE_GRANT_PUBLICATION_NO}}</b> <br> FK DT Document Type Name: <b>{{FK_DT_DOCUMENT_TYPE_NM}}</b> <br> Inventor String Tx: <b>{{INVENTOR_STRING_TX}}</b> <br> Status Code: <b>{{STATUS_CD}}</b> <br> Inventor Name: <b>{{INVENTOR_GIVEN_NM}} {{INVENTOR_MIDDLE_NM}} {{INVENTOR_FAMILY_NM}}</b> <br> Patent Issue Date: <b>{{PATENT_ISSUE_DT}}</b> <br> Decision Mailed Date: <b>{{DECISION_MAILED_DT}}</b> <br> Pre-Grant Publication Number: <b>{{PRE_GRANT_PUBLICATION_NO}}</b> <br> Applicant Pub Authorization Date: <b>{{APPLICANT_PUB_AUTHORIZATION_DT}}</b> <br> FK DT Business Short Name: <b>{{FK_DT_BUSINESS_SHORT_NM}}</b> <br> Application Type Code: <b>{{APPLICATION_TYPE_CD}}</b> <br> Appeal Number: <b>{{APPEAL_NO}}</b> <br> Inventor QT: <b>{{INVENTOR_QT}}</b> <br> Last Modified TS: <b>{{LAST_MODIFIED_TS}}</b> <br><hr><b>Full Text</b><hr>{{breaklines textdata}}' ;"  data-item="{{DOCUMENT_IMAGE_ID}}" data-toggle="modal" data-target="#cancelModal"> PTAB DOC ID: {{DOCUMENT_IMAGE_ID}}</a></h4>
               {{#with (lookup ../highlighting id) }}
                 {{#if textdata}}
                   {{#each textdata}}
                     <li>{{{this}}}</li>
                   {{/each}}
                 {{else}}
-                  {{{truncate ../textdata.[0]}}}...
+                  {{{truncate ../textdata}}}...
                 {{/if}}
               {{/with}}
               <hr>
@@ -35,7 +35,7 @@
       {{else}}
           {{#each result}}
             <div class="media row">
-              <h4 class="col-md-8"><a style="cursor:pointer"; onClick="javascript:document.getElementById('action_text').innerHTML =''; document.getElementById('action_text').innerHTML ='<h5>File Doc ID:{{appid}} - {{ifwnumber}} , Action Type: {{{convertDocCode documentcode}}}</h5><hr><b>Full Text</b><hr>{{breaklines textdata.[0]}}';"  data-item="{{filename}}" data-toggle="modal" data-target="#cancelModal">  Office Action ID: {{appid}} - {{ifwnumber}}</a> | {{{convertDocCode documentcode}}}</h4>
+              <h4 class="col-md-8"><a style="cursor:pointer"; onClick="javascript:document.getElementById('action_text').innerHTML =''; document.getElementById('action_text').innerHTML ='<h5>File Doc ID:{{appid}} - {{ifwnumber}} , Action Type: {{{convertDocCode documentcode}}}</h5><hr><b>Full Text</b><hr>{{breaklines textdata}}';"  data-item="{{filename}}" data-toggle="modal" data-target="#cancelModal">  Office Action ID: {{appid}} - {{ifwnumber}}</a> | {{{convertDocCode documentcode}}}</h4>
               <div class='col-md-1 col-md-offset-3'>
                 <a class='external-link' target="_blank" href='{{{hyperlinkIt "palm" appid}}}'><i class="icon icon-external-link"></i> PALM</a>
                 <a class='external-link' target="_blank" href='{{{hyperlinkIt "dav" appid}}}'><i class="icon icon-external-link"></i> DAV</a>

--- a/searchtool/server/views/newview.hbs
+++ b/searchtool/server/views/newview.hbs
@@ -46,7 +46,7 @@
                     <li>{{{this}}}</li>
                   {{/each}}
                 {{else}}
-                  {{{truncate ../textdata.[0]}}}...
+                  {{{truncate ../textdata}}}...
                 {{/if}}
               {{/with}}
               <hr>


### PR DESCRIPTION
Summary of changes:
- Trimmed `layout.hbs` from ~800 lines to ~200 lines
- Moved existing file to `layout_original.hbs` in case needed in future though it seems like it's just a copy of USPTO designpatterns templates
- Improved HTML structure with separate `search` and `refine search` forms instead of one `<form>` that expanded across multiple `<div>` elements. Refining works with hidden input elements.
- Improved UI of the app by adding navigation, uncollapsing filtering, and decluttering the page
- Consolidated the multiple `accessOK` conditionals on the front end and tweaked their placement
- Passed authentication object to /help route 
